### PR TITLE
Prepare release 2.0.0-M7

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ The implementation is based on the original BSD-licensed reference implementatio
 #### Usage
 
 The *scala-java-time* library is currently available for Scala (JVM, version 8 and later) and Scala.js (JavaScript).
-Both Scala 2.11 and Scala 2.12 (2.12.0-M6 and later) are supported.
+Both Scala 2.11 and Scala 2.12 (2.12.0-M7 and later) are supported.
 
 To get started with SBT, add one (or both) of these dependencies:
 
-- `libraryDependencies += "io.github.cquiroz" %%  "scala-java-time" % "2.0.0-M6"` (for Scala)
-- `libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-M6"` (for Scala.js, [Scala.js plugin](http://www.scala-js.org/tutorial/basic/#sbt-setup) required)
+- `libraryDependencies += "io.github.cquiroz" %%  "scala-java-time" % "2.0.0-M7"` (for Scala)
+- `libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-M7"` (for Scala.js, [Scala.js plugin](http://www.scala-js.org/tutorial/basic/#sbt-setup) required)
 
 #### Documentation
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,13 +10,22 @@ val crossScalaVer = Seq(scalaVer, "2.10.6", "2.12.0")
 lazy val commonSettings = Seq(
   name         := "scala-java-time",
   description  := "java.time API implementation in Scala and Scala.js",
-  version      := "2.0.0-M6",
+  version      := "2.0.0-M7",
   organization := "io.github.cquiroz",
   homepage     := Some(url("https://github.com/cquiroz/scala-java-time")),
   licenses     := Seq("BSD 3-Clause License" -> url("https://opensource.org/licenses/BSD-3-Clause")),
 
   scalaVersion       := scalaVer,
   crossScalaVersions := crossScalaVer,
+  autoAPIMappings    := true,
+
+  scalacOptions in Compile ++= Seq(
+    "-deprecation",
+    "-feature",
+    // Enable when documentation does not produce warnings
+    //"-Xfatal-warnings",
+    "-encoding", "UTF-8"
+  ),
 
   publishArtifact in Test := false,
   publishMavenStyle := true,
@@ -104,7 +113,7 @@ lazy val scalajavatime = crossProject.crossType(CrossType.Full).in(file("."))
       }.taskValue,
     parallelExecution in Test := false,
     libraryDependencies ++= Seq(
-      "io.github.cquiroz" %%% "scala-java-locales" % "0.5.0-cldr30"
+      "com.github.cquiroz" %%% "scala-java-locales" % "0.3.1-cldr30"
     )
   )
 

--- a/changes.xml
+++ b/changes.xml
@@ -8,6 +8,19 @@
   </properties>
   <body>
     <!-- types are add, fix, remove, update -->
+    <release version="2.0.0-M7" date="2017-01-16" description="v2.0.0-M7">
+      <action dev="cquiroz" type="update" >
+        Downgrade to scala-java-locales 0.3.1-cldr30 to reduce the exported js size
+      </action>
+    </release>
+    <release version="2.0.0-M6" date="2016-12-08" description="v2.0.0-M6">
+      <action dev="cquiroz" type="update" >
+        Exports in both org.threeten.bp and java.time packages
+      </action>
+      <action dev="cquiroz" type="update" >
+        Published under a new organization
+      </action>
+    </release>
     <release version="2.0.0-M5" date="2016-11-08" description="v2.0.0-M5">
       <action dev="cquiroz" type="fix" >
         Fix #47: Test failures on TestDateTimeFormatters on Scala 2.12

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -17,7 +17,8 @@ The implementation is based on the original BSD-licensed reference implementatio
 
 ```tut:book
 // You can pick either java.time or org.threeten.bp package to import
-import java.time._
+//import java.time._
+import org.threeten.bp._
 
 // always returns 2009-02-13T23:31:30
 val fixedClock = Clock.fixed(Instant.ofEpochSecond(1234567890L), ZoneOffset.ofHours(0))
@@ -55,12 +56,12 @@ chrono.MinguoDate.now(fixedClock).toString       == "Minguo ROC 98-02-13"
 #### Usage
 
 The *scala-java-time* library is currently available for Scala (JVM, version 8 and later) and Scala.js (JavaScript).
-Both Scala 2.11 and Scala 2.12 (2.12.0-M6 and later) are supported.
+Both Scala 2.11 and Scala 2.12 (2.12.0-M7 and later) are supported.
 
 To get started with SBT, add one (or both) of these dependencies:
 
-- `libraryDependencies += "io.github.cquiroz" %%  "scala-java-time" % "2.0.0-M6"` (for Scala)
-- `libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-M6"` (for Scala.js, [Scala.js plugin](http://www.scala-js.org/tutorial/basic/#sbt-setup) required)
+- `libraryDependencies += "io.github.cquiroz" %%  "scala-java-time" % "2.0.0-M7"` (for Scala)
+- `libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-M7"` (for Scala.js, [Scala.js plugin](http://www.scala-js.org/tutorial/basic/#sbt-setup) required)
 
 #### Building
 This project builds using sbt.
@@ -109,4 +110,4 @@ Thus, this project is a fork of the original code before entry to OpenJDK.
 
 ##### What is the relation to [this](https://github.com/soc/scala-java-time/) project
 
-This is a fork from the original [project](https://github.com/soc/scala-java-time/) aim to complete the API to work on Scala.js 
+This is a fork from the original [project](https://github.com/soc/scala-java-time/) aim to complete the API to work on Scala.js


### PR DESCRIPTION
The scala-java-locales version has been downgraded to reduce the exported javascript size
Fixes #13 