### PR TITLE
Use optimized code generator

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,6 +17,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 // addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 
 libraryDependencies ++= Seq(
-  "io.github.cquiroz" %% "kuyfi" % "0.4.0",
+  "io.github.cquiroz" %% "kuyfi" % "0.5.0",
   "org.apache.commons" % "commons-compress" % "1.12"
 )

--- a/project/src/main/scala/TZDBTasks.scala
+++ b/project/src/main/scala/TZDBTasks.scala
@@ -1,6 +1,7 @@
 import java.io.File
 
 import kuyfi.TZDBCodeGenerator
+import kuyfi.TZDBCodeGenerator.OptimizedTreeGenerator._
 
 object TZDBTasks {
 


### PR DESCRIPTION
This PR brings the latest time zone db which produces a much smaller output at the cost of readability.

A sample demo using a single timezone produces a fast/full optimized js of size:

* **before this PR**
fast/full
10501722/1517932

* **after this PR**
fast/full
2837605/981000

* Note that the size without tz usage is:
fast/full
1672688/372915

I don't expect this code to be the final way to provide a tzdb, instead a system where you can build your own db would produce smaller files and simpler to maintain

However this is already usable and could be released