### PR TITLE
Fix for compareTo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -136,7 +136,10 @@ lazy val scalajavatime = crossProject.crossType(CrossType.Full).in(file("."))
     sourceGenerators in Test += Def.task {
         val srcDirs = (sourceDirectories in Test).value
         val destinationDir = (sourceManaged in Test).value
-        copyAndReplace(srcDirs, destinationDir)
+        copyAndReplace(srcDirs, destinationDir).filterNot { f =>
+          // I can't get this test to compile on both JVM and JS
+          f.name.contains("TestDateTimeTextPrinting.scala") || f.name.contains("TestZonedDateTime")
+        }
       }.taskValue,
     parallelExecution in Test := false,
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -133,6 +133,11 @@ lazy val scalajavatime = crossProject.crossType(CrossType.Full).in(file("."))
         val destinationDir = (sourceManaged in Compile).value
         copyAndReplace(srcDirs, destinationDir)
       }.taskValue,
+    sourceGenerators in Test += Def.task {
+        val srcDirs = (sourceDirectories in Test).value
+        val destinationDir = (sourceManaged in Test).value
+        copyAndReplace(srcDirs, destinationDir)
+      }.taskValue,
     parallelExecution in Test := false,
     libraryDependencies ++= Seq(
       "com.github.cquiroz" %%% "scala-java-locales" % "0.3.1-cldr30"

--- a/shared/src/main/scala/org/threeten/bp/Duration.scala
+++ b/shared/src/main/scala/org/threeten/bp/Duration.scala
@@ -957,6 +957,9 @@ final class Duration private(private val seconds: Long, private val nanos: Int) 
     else nanos - otherDuration.nanos
   }
 
+
+  override def compareTo(other: Duration): Int = compare(other)
+
   /** Checks if this duration is equal to the specified {@code Duration}.
     *
     * The comparison is based on the total length of the durations.

--- a/shared/src/main/scala/org/threeten/bp/Instant.scala
+++ b/shared/src/main/scala/org/threeten/bp/Instant.scala
@@ -961,6 +961,8 @@ final class Instant private(private val seconds: Long, private val nanos: Int) e
     else nanos - otherInstant.nanos
   }
 
+  override def compareTo(other: Instant): Int = compare(other)
+
   /** Checks if this instant is after the specified instant.
     *
     * The comparison is based on the time-line position of the instants.

--- a/shared/src/main/scala/org/threeten/bp/LocalTime.scala
+++ b/shared/src/main/scala/org/threeten/bp/LocalTime.scala
@@ -1201,6 +1201,8 @@ final class LocalTime(_hour: Int, _minute: Int, _second: Int, private val nano: 
     cmp
   }
 
+  override def compareTo(other: LocalTime): Int = compare(other)
+
   /** Checks if this {@code LocalTime} is after the specified time.
     *
     * The comparison is based on the time-line position of the time within a day.

--- a/shared/src/main/scala/org/threeten/bp/OffsetDateTime.scala
+++ b/shared/src/main/scala/org/threeten/bp/OffsetDateTime.scala
@@ -1418,6 +1418,8 @@ final class OffsetDateTime private(private val dateTime: LocalDateTime, private 
     cmp
   }
 
+  override def compareTo(other: OffsetDateTime): Int = compare(other)
+
   /** Checks if the instant of this date-time is after that of the specified date-time.
     *
     * This method differs from the comparison in {@link #compareTo} and {@link #equals} in that it

--- a/shared/src/main/scala/org/threeten/bp/OffsetTime.scala
+++ b/shared/src/main/scala/org/threeten/bp/OffsetTime.scala
@@ -977,6 +977,8 @@ final class OffsetTime(private val time: LocalTime, private val offset: ZoneOffs
       compare
     }
 
+  override def compareTo(other: OffsetTime): Int = compare(other)
+
   /** Checks if the instant of this {@code OffsetTime} is after that of the
     * specified time applying both times to a common date.
     *

--- a/shared/src/main/scala/org/threeten/bp/ZoneOffset.scala
+++ b/shared/src/main/scala/org/threeten/bp/ZoneOffset.scala
@@ -561,6 +561,8 @@ final class ZoneOffset private(private val totalSeconds: Int) extends ZoneId wit
     */
   def compare(other: ZoneOffset): Int = other.totalSeconds - totalSeconds
 
+  override def compareTo(other: ZoneOffset): Int = compare(other)
+
   /** Checks if this offset is equal to another offset.
     *
     * The comparison is based on the amount of the offset in seconds.

--- a/shared/src/main/scala/org/threeten/bp/zone/ZoneOffsetTransition.scala
+++ b/shared/src/main/scala/org/threeten/bp/zone/ZoneOffsetTransition.scala
@@ -269,6 +269,8 @@ final class ZoneOffsetTransition private[zone](private val transition: LocalDate
     */
   def compare(transition: ZoneOffsetTransition): Int = this.getInstant.compareTo(transition.getInstant)
 
+  override def compareTo(other: ZoneOffsetTransition): Int = compare(other)
+
   /** Checks if this object equals another.
     *
     * The entire state of the object is compared.

--- a/shared/src/test/scala/org/threeten/bp/TestDayOfWeek.scala
+++ b/shared/src/test/scala/org/threeten/bp/TestDayOfWeek.scala
@@ -233,6 +233,6 @@ class TestDayOfWeek extends FunSuite with GenDateTimeTest with AssertionsHelper 
 
   test("enum") {
     assertEquals(DayOfWeek.valueOf("MONDAY"), DayOfWeek.MONDAY)
-    assertEquals(DayOfWeek.values(0), DayOfWeek.MONDAY)
+    assertEquals(DayOfWeek.values.apply(0), DayOfWeek.MONDAY)
   }
 }

--- a/shared/src/test/scala/org/threeten/bp/TestLocalTime.scala
+++ b/shared/src/test/scala/org/threeten/bp/TestLocalTime.scala
@@ -396,31 +396,31 @@ class TestLocalTime extends FunSuite with GenDateTimeTest with AssertionsHelper 
   }
 
   test("factory_ofSecondOfDay_long_int") {
-    val localTime: LocalTime = LocalTime.ofSecondOfDay(2 * 60 * 60 + 17 * 60 + 23, 987)
+    val localTime: LocalTime = LocalTime.ofSecondOfDay(2 * 60 * 60 + 17 * 60 + 23).withNano(987)
     check(localTime, 2, 17, 23, 987)
   }
 
   test("factory_ofSecondOfDay_long_int_tooLowSecs") {
     assertThrows[DateTimeException] {
-      LocalTime.ofSecondOfDay(-1, 0)
+      LocalTime.ofSecondOfDay(-1).withNano(0)
     }
   }
 
   test("factory_ofSecondOfDay_long_int_tooHighSecs") {
     assertThrows[DateTimeException] {
-      LocalTime.ofSecondOfDay(24 * 60 * 60, 0)
+      LocalTime.ofSecondOfDay(24 * 60 * 60).withNano(0)
     }
   }
 
   test("factory_ofSecondOfDay_long_int_tooLowNanos") {
     assertThrows[DateTimeException] {
-      LocalTime.ofSecondOfDay(0, -1)
+      LocalTime.ofSecondOfDay(0).withNano(-1)
     }
   }
 
   test("factory_ofSecondOfDay_long_int_tooHighNanos") {
     assertThrows[DateTimeException] {
-      LocalTime.ofSecondOfDay(0, 1000000000)
+      LocalTime.ofSecondOfDay(0).withNano(1000000000)
     }
   }
 

--- a/shared/src/test/scala/org/threeten/bp/TestLocalTime.scala
+++ b/shared/src/test/scala/org/threeten/bp/TestLocalTime.scala
@@ -865,7 +865,7 @@ class TestLocalTime extends FunSuite with GenDateTimeTest with AssertionsHelper 
       true
     }
 
-    def isSupportedBy(temporal: Temporal): Boolean = {
+    override def isSupportedBy(temporal: Temporal): Boolean = {
       false
     }
 
@@ -898,7 +898,7 @@ class TestLocalTime extends FunSuite with GenDateTimeTest with AssertionsHelper 
       true
     }
 
-    def isSupportedBy(temporal: Temporal): Boolean = {
+    override def isSupportedBy(temporal: Temporal): Boolean = {
       false
     }
 

--- a/shared/src/test/scala/org/threeten/bp/TestMonth.scala
+++ b/shared/src/test/scala/org/threeten/bp/TestMonth.scala
@@ -282,6 +282,6 @@ class TestMonth extends FunSuite with GenDateTimeTest with AssertionsHelper {
 
   test("enum") {
     assertEquals(Month.valueOf("JANUARY"), Month.JANUARY)
-    assertEquals(Month.values(0), Month.JANUARY)
+    assertEquals(Month.values.apply(0), Month.JANUARY)
   }
 }

--- a/shared/src/test/scala/org/threeten/bp/temporal/MockFieldNoValue.scala
+++ b/shared/src/test/scala/org/threeten/bp/temporal/MockFieldNoValue.scala
@@ -53,7 +53,7 @@ final class MockFieldNoValue(name: String, ordinal: Int) extends Enum[MockFieldN
   def rangeRefinedBy(dateTime: TemporalAccessor): ValueRange = ValueRange.of(1, 20)
   def getFrom(dateTime: TemporalAccessor): Long = throw new DateTimeException("Mock")
   def adjustInto[R <: Temporal](dateTime: R, newValue: Long): R = throw new DateTimeException("Mock")
-  def getDisplayName(locale: Locale): String = "Mock"
-  def resolve(fieldValues: java.util.Map[TemporalField, java.lang.Long], partialTemporal: TemporalAccessor, resolverStyle: ResolverStyle): TemporalAccessor =
+  override def getDisplayName(locale: Locale): String = "Mock"
+  override def resolve(fieldValues: java.util.Map[TemporalField, java.lang.Long], partialTemporal: TemporalAccessor, resolverStyle: ResolverStyle): TemporalAccessor =
     null
 }

--- a/shared/src/test/scala/org/threeten/bp/zone/TestFixedZoneRules.scala
+++ b/shared/src/test/scala/org/threeten/bp/zone/TestFixedZoneRules.scala
@@ -166,7 +166,7 @@ class TestFixedZoneRules extends FunSuite with AssertionsHelper {
   test("getTransitionRules_immutable") {
     assertThrows[UnsupportedOperationException] {
       val test: ZoneRules = make(TestFixedZoneRules.OFFSET_PTWO)
-      test.getTransitionRules.add(ZoneOffsetTransitionRule.of(Month.JULY, 2, null, LocalTime.of(12, 30), timeEndOfDay = false, TimeDefinition.STANDARD, TestFixedZoneRules.OFFSET_PONE, TestFixedZoneRules.OFFSET_PTWO, TestFixedZoneRules.OFFSET_PONE))
+      test.getTransitionRules.add(ZoneOffsetTransitionRule.of(Month.JULY, 2, null, LocalTime.of(12, 30), false, TimeDefinition.STANDARD, TestFixedZoneRules.OFFSET_PONE, TestFixedZoneRules.OFFSET_PTWO, TestFixedZoneRules.OFFSET_PONE))
     }
   }
 

--- a/shared/src/test/scala/org/threeten/bp/zone/TestZoneOffsetTransitionRule.scala
+++ b/shared/src/test/scala/org/threeten/bp/zone/TestZoneOffsetTransitionRule.scala
@@ -45,66 +45,66 @@ object TestZoneOffsetTransitionRule {
 class TestZoneOffsetTransitionRule extends FunSuite with AssertionsHelper {
   test("factory_nullMonth") {
     assertThrows[NullPointerException] {
-      ZoneOffsetTransitionRule.of(null, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+      ZoneOffsetTransitionRule.of(null, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     }
   }
 
   test("factory_nullTime") {
     assertThrows[NullPointerException] {
-      ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, null, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+      ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, null, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     }
   }
 
   test("factory_nullTimeDefinition") {
     assertThrows[NullPointerException] {
-      ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, null, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+      ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, null, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     }
   }
 
   test("factory_nullStandardOffset") {
     assertThrows[NullPointerException] {
-      ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, null, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+      ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, null, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     }
   }
 
   test("factory_nullOffsetBefore") {
     assertThrows[NullPointerException] {
-      ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, null, TestZoneOffsetTransitionRule.OFFSET_0300)
+      ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, null, TestZoneOffsetTransitionRule.OFFSET_0300)
     }
   }
 
   test("factory_nullOffsetAfter") {
     assertThrows[NullPointerException] {
-      ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, null)
+      ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, null)
     }
   }
 
   test("factory_invalidDayOfMonthIndicator_tooSmall") {
     assertThrows[IllegalArgumentException] {
-      ZoneOffsetTransitionRule.of(Month.MARCH, -29, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+      ZoneOffsetTransitionRule.of(Month.MARCH, -29, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     }
   }
 
   test("factory_invalidDayOfMonthIndicator_zero") {
     assertThrows[IllegalArgumentException] {
-      ZoneOffsetTransitionRule.of(Month.MARCH, 0, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+      ZoneOffsetTransitionRule.of(Month.MARCH, 0, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     }
   }
 
   test("factory_invalidDayOfMonthIndicator_tooLarge") {
     assertThrows[IllegalArgumentException] {
-      ZoneOffsetTransitionRule.of(Month.MARCH, 32, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+      ZoneOffsetTransitionRule.of(Month.MARCH, 32, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     }
   }
 
   test("factory_invalidMidnightFlag") {
     assertThrows[IllegalArgumentException] {
-      ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = true, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+      ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, true, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     }
   }
 
   test("getters_floatingWeek") {
-    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(test.getMonth, Month.MARCH)
     assertEquals(test.getDayOfMonthIndicator, 20)
     assertEquals(test.getDayOfWeek, DayOfWeek.SUNDAY)
@@ -117,7 +117,7 @@ class TestZoneOffsetTransitionRule extends FunSuite with AssertionsHelper {
   }
 
   test("getters_floatingWeekBackwards") {
-    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -1, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -1, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(test.getMonth, Month.MARCH)
     assertEquals(test.getDayOfMonthIndicator, -1)
     assertEquals(test.getDayOfWeek, DayOfWeek.SUNDAY)
@@ -130,7 +130,7 @@ class TestZoneOffsetTransitionRule extends FunSuite with AssertionsHelper {
   }
 
   test("getters_fixedDate") {
-    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, null, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, null, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(test.getMonth, Month.MARCH)
     assertEquals(test.getDayOfMonthIndicator, 20)
     assertEquals(test.getDayOfWeek, null)
@@ -143,44 +143,44 @@ class TestZoneOffsetTransitionRule extends FunSuite with AssertionsHelper {
   }
 
   test("createTransition_floatingWeek_gap_notEndOfDay") {
-    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     val trans: ZoneOffsetTransition = new ZoneOffsetTransition(LocalDateTime.of(2000, Month.MARCH, 26, 1, 0), TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(test.createTransition(2000), trans)
   }
 
   test("createTransition_floatingWeek_overlap_endOfDay") {
-    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, LocalTime.MIDNIGHT, timeEndOfDay = true, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300, TestZoneOffsetTransitionRule.OFFSET_0200)
+    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, LocalTime.MIDNIGHT, true, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300, TestZoneOffsetTransitionRule.OFFSET_0200)
     val trans: ZoneOffsetTransition = new ZoneOffsetTransition(LocalDateTime.of(2000, Month.MARCH, 27, 0, 0), TestZoneOffsetTransitionRule.OFFSET_0300, TestZoneOffsetTransitionRule.OFFSET_0200)
     assertEquals(test.createTransition(2000), trans)
   }
 
   test("createTransition_floatingWeekBackwards_last") {
-    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -1, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -1, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     val trans: ZoneOffsetTransition = new ZoneOffsetTransition(LocalDateTime.of(2000, Month.MARCH, 26, 1, 0), TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(test.createTransition(2000), trans)
   }
 
   test("createTransition_floatingWeekBackwards_seventhLast") {
-    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -7, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -7, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     val trans: ZoneOffsetTransition = new ZoneOffsetTransition(LocalDateTime.of(2000, Month.MARCH, 19, 1, 0), TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(test.createTransition(2000), trans)
   }
 
   test("createTransition_floatingWeekBackwards_secondLast") {
-    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -2, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -2, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     val trans: ZoneOffsetTransition = new ZoneOffsetTransition(LocalDateTime.of(2000, Month.MARCH, 26, 1, 0), TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(test.createTransition(2000), trans)
   }
 
   test("createTransition_fixedDate") {
-    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, null, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.STANDARD, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, null, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.STANDARD, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     val trans: ZoneOffsetTransition = new ZoneOffsetTransition(LocalDateTime.of(2000, Month.MARCH, 20, 1, 0), TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(test.createTransition(2000), trans)
   }
 
   test("equals_monthDifferent") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
-    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.APRIL, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.APRIL, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(a == a, true)
     assertEquals(a == b, false)
     assertEquals(b == a, false)
@@ -188,8 +188,8 @@ class TestZoneOffsetTransitionRule extends FunSuite with AssertionsHelper {
   }
 
   test("equals_dayOfMonthDifferent") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
-    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 21, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 21, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(a == a, true)
     assertEquals(a == b, false)
     assertEquals(b == a, false)
@@ -197,8 +197,8 @@ class TestZoneOffsetTransitionRule extends FunSuite with AssertionsHelper {
   }
 
   test("equals_dayOfWeekDifferent") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
-    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SATURDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SATURDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(a == a, true)
     assertEquals(a == b, false)
     assertEquals(b == a, false)
@@ -206,8 +206,8 @@ class TestZoneOffsetTransitionRule extends FunSuite with AssertionsHelper {
   }
 
   test("equals_dayOfWeekDifferentNull") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
-    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, null, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, null, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(a == a, true)
     assertEquals(a == b, false)
     assertEquals(b == a, false)
@@ -215,8 +215,8 @@ class TestZoneOffsetTransitionRule extends FunSuite with AssertionsHelper {
   }
 
   test("equals_localTimeDifferent") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
-    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, LocalTime.MIDNIGHT, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, LocalTime.MIDNIGHT, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(a == a, true)
     assertEquals(a == b, false)
     assertEquals(b == a, false)
@@ -224,8 +224,8 @@ class TestZoneOffsetTransitionRule extends FunSuite with AssertionsHelper {
   }
 
   test("equals_endOfDayDifferent") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, LocalTime.MIDNIGHT, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
-    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, LocalTime.MIDNIGHT, timeEndOfDay = true, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, LocalTime.MIDNIGHT, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, LocalTime.MIDNIGHT, true, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(a == a, true)
     assertEquals(a == b, false)
     assertEquals(b == a, false)
@@ -233,8 +233,8 @@ class TestZoneOffsetTransitionRule extends FunSuite with AssertionsHelper {
   }
 
   test("equals_timeDefinitionDifferent") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
-    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.STANDARD, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.STANDARD, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(a == a, true)
     assertEquals(a == b, false)
     assertEquals(b == a, false)
@@ -242,8 +242,8 @@ class TestZoneOffsetTransitionRule extends FunSuite with AssertionsHelper {
   }
 
   test("equals_standardOffsetDifferent") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
-    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0300, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0300, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(a == a, true)
     assertEquals(a == b, false)
     assertEquals(b == a, false)
@@ -251,8 +251,8 @@ class TestZoneOffsetTransitionRule extends FunSuite with AssertionsHelper {
   }
 
   test("equals_offsetBeforeDifferent") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
-    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(a == a, true)
     assertEquals(a == b, false)
     assertEquals(b == a, false)
@@ -260,8 +260,8 @@ class TestZoneOffsetTransitionRule extends FunSuite with AssertionsHelper {
   }
 
   test("equals_offsetAfterDifferent") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
-    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200)
     assertEquals(a == a, true)
     assertEquals(a == b, false)
     assertEquals(b == a, false)
@@ -269,61 +269,61 @@ class TestZoneOffsetTransitionRule extends FunSuite with AssertionsHelper {
   }
 
   test("equals_string_false") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertNotEquals(a, "TZDB")
   }
 
   test("equals_null_false") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(a == null, false)
   }
 
   test("hashCode_floatingWeek_gap_notEndOfDay") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
-    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(a.hashCode, b.hashCode)
   }
 
   test("hashCode_floatingWeek_overlap_endOfDay_nullDayOfWeek") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.OCTOBER, 20, null, LocalTime.MIDNIGHT, timeEndOfDay = true, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300, TestZoneOffsetTransitionRule.OFFSET_0200)
-    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.OCTOBER, 20, null, LocalTime.MIDNIGHT, timeEndOfDay = true, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300, TestZoneOffsetTransitionRule.OFFSET_0200)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.OCTOBER, 20, null, LocalTime.MIDNIGHT, true, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300, TestZoneOffsetTransitionRule.OFFSET_0200)
+    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.OCTOBER, 20, null, LocalTime.MIDNIGHT, true, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300, TestZoneOffsetTransitionRule.OFFSET_0200)
     assertEquals(a.hashCode, b.hashCode)
   }
 
   test("hashCode_floatingWeekBackwards") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -1, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
-    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -1, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -1, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -1, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(a.hashCode, b.hashCode)
   }
 
   test("hashCode_fixedDate") {
-    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, null, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.STANDARD, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
-    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, null, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.STANDARD, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val a: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, null, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.STANDARD, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val b: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, null, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.STANDARD, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(a.hashCode, b.hashCode)
   }
 
   test("toString_floatingWeek_gap_notEndOfDay") {
-    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(test.toString, "TransitionRule[Gap +02:00 to +03:00, SUNDAY on or after MARCH 20 at 01:00 WALL, standard offset +02:00]")
   }
 
   test("toString_floatingWeek_overlap_endOfDay") {
-    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.OCTOBER, 20, DayOfWeek.SUNDAY, LocalTime.MIDNIGHT, timeEndOfDay = true, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300, TestZoneOffsetTransitionRule.OFFSET_0200)
+    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.OCTOBER, 20, DayOfWeek.SUNDAY, LocalTime.MIDNIGHT, true, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300, TestZoneOffsetTransitionRule.OFFSET_0200)
     assertEquals(test.toString, "TransitionRule[Overlap +03:00 to +02:00, SUNDAY on or after OCTOBER 20 at 24:00 WALL, standard offset +02:00]")
   }
 
   test("toString_floatingWeekBackwards_last") {
-    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -1, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -1, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(test.toString, "TransitionRule[Gap +02:00 to +03:00, SUNDAY on or before last day of MARCH at 01:00 WALL, standard offset +02:00]")
   }
 
   test("toString_floatingWeekBackwards_secondLast") {
-    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -2, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, -2, DayOfWeek.SUNDAY, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.WALL, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(test.toString, "TransitionRule[Gap +02:00 to +03:00, SUNDAY on or before last day minus 1 of MARCH at 01:00 WALL, standard offset +02:00]")
   }
 
   test("toString_fixedDate") {
-    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, null, TestZoneOffsetTransitionRule.TIME_0100, timeEndOfDay = false, TimeDefinition.STANDARD, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
+    val test: ZoneOffsetTransitionRule = ZoneOffsetTransitionRule.of(Month.MARCH, 20, null, TestZoneOffsetTransitionRule.TIME_0100, false, TimeDefinition.STANDARD, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0200, TestZoneOffsetTransitionRule.OFFSET_0300)
     assertEquals(test.toString, "TransitionRule[Gap +02:00 to +03:00, MARCH 20 at 01:00 STANDARD, standard offset +02:00]")
   }
 }

--- a/shared/src/test/scala/org/threeten/bp/zone/TestZoneRulesProvider.scala
+++ b/shared/src/test/scala/org/threeten/bp/zone/TestZoneRulesProvider.scala
@@ -78,28 +78,28 @@ class TestZoneRulesProvider extends FunSuite with AssertionsHelper {
   }
 
   test("getRules_String") {
-    val rules: ZoneRules = ZoneRulesProvider.getRules("Europe/London", forCaching = false)
+    val rules: ZoneRules = ZoneRulesProvider.getRules("Europe/London",  false)
     assertTrue(rules != null)
-    val rules2: ZoneRules = ZoneRulesProvider.getRules("Europe/London", forCaching = false)
+    val rules2: ZoneRules = ZoneRulesProvider.getRules("Europe/London",  false)
     assertTrue(rules2 == rules)
   }
 
   test("getRules_String_unknownId") {
     assertThrows[ZoneRulesException] {
-      ZoneRulesProvider.getRules("Europe/Lon", forCaching = false)
+      ZoneRulesProvider.getRules("Europe/Lon",  false)
     }
   }
 
   test("getRules_String_null") {
     assertThrows[NullPointerException] {
-      ZoneRulesProvider.getRules(null, forCaching = false)
+      ZoneRulesProvider.getRules(null,  false)
     }
   }
 
   test("getVersions_String") {
     val versions: java.util.NavigableMap[String, ZoneRules] = ZoneRulesProvider.getVersions("Europe/London")
     assertTrue(versions.size >= 1)
-    val rules: ZoneRules = ZoneRulesProvider.getRules("Europe/London", forCaching = false)
+    val rules: ZoneRules = ZoneRulesProvider.getRules("Europe/London",  false)
     assertTrue(versions.lastEntry.getValue == rules)
     val copy = new java.util.HashMap[String, ZoneRules](versions)
     versions.clear()
@@ -131,6 +131,6 @@ class TestZoneRulesProvider extends FunSuite with AssertionsHelper {
     assertTrue(!pre.contains("FooLocation"))
     val post: java.util.Set[String] = ZoneRulesProvider.getAvailableZoneIds
     assertTrue(post.contains("FooLocation"))
-    assertTrue(ZoneRulesProvider.getRules("FooLocation", forCaching = false) == ZoneOffset.of("+01:45").getRules)
+    assertTrue(ZoneRulesProvider.getRules("FooLocation",  false) == ZoneOffset.of("+01:45").getRules)
   }
 }


### PR DESCRIPTION
This PR fixes #26 implementing `compareTo` on the affected classes

The build has been updated to run most tests on the `java.time` and `org.threeten.bp` packages to detect this kind of issues