### PR TITLE
Fix for zone tests

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -3,10 +3,17 @@
 <document>
   <properties>
     <title>Changes</title>
+    <author>Carlos Quiroz (Scala port and maintainer)</author>
     <author>Simon Ochsenreither (Scala port)</author>
     <author>Stephen Colebourne (Java version)</author>
   </properties>
   <body>
+    <!-- types are add, fix, remove, update -->
+    <release version="2.0.0-M11" date="2017-04-16" description="v2.0.0-M11">
+      <action dev="alonsodomin" type="update" >
+        Support localized timezone names
+      </action>
+    </release>
     <!-- types are add, fix, remove, update -->
     <release version="2.0.0-M10" date="2017-04-16" description="v2.0.0-M10">
       <action dev="cquiroz" type="update" >

--- a/js/src/main/scala/org/threeten/bp/zone/TzdbZoneRulesProvider.scala
+++ b/js/src/main/scala/org/threeten/bp/zone/TzdbZoneRulesProvider.scala
@@ -20,8 +20,8 @@ final class TzdbZoneRulesProvider extends ZoneRulesProvider {
   override protected def provideZoneIds: java.util.Set[String] = {
     val zones = new java.util.HashSet((stdZonesMap.keySet ++ fixedZonesMap.keySet ++ zoneLinks.keySet).asJava)
     // I'm not totallly sure the reason why but TTB removes these ZoneIds
-    zones.remove("UTC")
-    zones.remove("GMT")
+    // zones.remove("UTC")
+    // zones.remove("GMT")
     zones.remove("GMT0")
     zones.remove("GMT+0")
     zones.remove("GMT-0")


### PR DESCRIPTION
This PR fixes some broken tests. The code below removed `UTC` and `GMT` from the list of zones like the java side does but that is a mistake