### PR TITLE
Restore skipped tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ cache:
     - $HOME/.sbt/boot
 
 script:
+  - sudo chmod +x /usr/local/bin/sbt
   - sbt ++$TRAVIS_SCALA_VERSION clean scalajavatimeJVM/test scalajavatimeJS/test scalajavatimeJVM/publishLocal scalajavatimeJS/publishLocal docs/makeMicrosite
   # Tricks to avoid unnecessary cache updates, from
   # http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html

--- a/build.sbt
+++ b/build.sbt
@@ -161,10 +161,7 @@ lazy val scalajavatime = crossProject.crossType(CrossType.Full).in(file("."))
     sourceGenerators in Test += Def.task {
         val srcDirs = (sourceDirectories in Test).value
         val destinationDir = (sourceManaged in Test).value
-        copyAndReplace(srcDirs, destinationDir).filterNot { f =>
-          // I can't get this test to compile on both JVM and JS
-          f.name.contains("TestDateTimeTextPrinting.scala") || f.name.contains("TestZonedDateTime")
-        }
+        copyAndReplace(srcDirs, destinationDir)
       }.taskValue,
     parallelExecution in Test := false,
     libraryDependencies ++= Seq(

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -111,3 +111,9 @@ Thus, this project is a fork of the original code before entry to OpenJDK.
 ##### What is the relation to [this](https://github.com/soc/scala-java-time/) project
 
 This is a fork from the original [project](https://github.com/soc/scala-java-time/) aim to complete the API to work on Scala.js
+
+##### Are there are differences with the Java Time API?
+
+The project aims to be an exact port of the java time API to scala.
+The only differences are classes not on the official java API but still present as private, e.g. `DateTimeTextProvider`
+in the format package that have been moved to the `internal` package to ease compatibility across versions

--- a/shared/src/main/scala/org/threeten/bp/ZonedDateTime.scala
+++ b/shared/src/main/scala/org/threeten/bp/ZonedDateTime.scala
@@ -744,6 +744,8 @@ final class ZonedDateTime(private val dateTime: LocalDateTime, private val offse
     this
   }
 
+  override def compareTo(other: ChronoZonedDateTime[_]): Int = super.compare(other)
+
   /** Gets the time-zone, such as 'Europe/Paris'.
     *
     * This returns the zone ID. This identifies the time-zone {@link ZoneRules rules}

--- a/shared/src/main/scala/org/threeten/bp/format/DateTimeFormatter.scala
+++ b/shared/src/main/scala/org/threeten/bp/format/DateTimeFormatter.scala
@@ -47,6 +47,7 @@ import java.text.ParseException
 import java.text.ParsePosition
 import java.lang.StringBuilder
 import java.util.{Arrays, Collections, Locale, Objects}
+import java.lang.Long
 
 import org.threeten.bp.DateTimeException
 import org.threeten.bp.Period

--- a/shared/src/main/scala/org/threeten/bp/format/DateTimeFormatterBuilder.scala
+++ b/shared/src/main/scala/org/threeten/bp/format/DateTimeFormatterBuilder.scala
@@ -31,18 +31,12 @@
  */
 package org.threeten.bp.format
 
-import java.math.BigDecimal
-import java.math.BigInteger
-import java.math.RoundingMode
 import java.text.DateFormat
 import java.text.SimpleDateFormat
-import java.util.{Collections, Comparator, Locale, MissingResourceException, Objects, ResourceBundle, TimeZone}
+import java.util.{Collections, Comparator, Locale, Objects}
 import java.lang.StringBuilder
+import java.lang.Long
 
-import org.threeten.bp.DateTimeException
-import org.threeten.bp.Instant
-import org.threeten.bp.LocalDate
-import org.threeten.bp.LocalDateTime
 import org.threeten.bp.ZoneId
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.chrono.ChronoLocalDate
@@ -53,13 +47,9 @@ import org.threeten.bp.temporal.TemporalAccessor
 import org.threeten.bp.temporal.TemporalField
 import org.threeten.bp.temporal.TemporalQueries
 import org.threeten.bp.temporal.TemporalQuery
-import org.threeten.bp.temporal.ValueRange
-import org.threeten.bp.temporal.WeekFields
-import org.threeten.bp.zone.ZoneRulesProvider
-import org.threeten.bp.format.internal.TTBPDateTimeFormatterBuilder.ZoneIdPrinterParser.SubstringTree
-import org.threeten.bp.format.internal.{TTBPDateTimeFormatterBuilder, TTBPDateTimeParseContext, TTBPDateTimePrintContext}
-
-import scala.annotation.tailrec
+import org.threeten.bp.format.internal.TTBPDateTimeTextProvider
+import org.threeten.bp.format.internal.TTBPSimpleDateTimeTextProvider
+import org.threeten.bp.format.internal.TTBPDateTimeFormatterBuilder
 
 object DateTimeFormatterBuilder {
   /** Query for a time-zone that is region-only. */
@@ -619,7 +609,7 @@ final class DateTimeFormatterBuilder private(private val parent: DateTimeFormatt
   def appendText(field: TemporalField, textStyle: TextStyle): DateTimeFormatterBuilder = {
     Objects.requireNonNull(field, "field")
     Objects.requireNonNull(textStyle, "textStyle")
-    appendInternal(new TTBPDateTimeFormatterBuilder.TextPrinterParser(field, textStyle, DateTimeTextProvider.getInstance))
+    appendInternal(new TTBPDateTimeFormatterBuilder.TextPrinterParser(field, textStyle, TTBPDateTimeTextProvider.getInstance))
     this
   }
 
@@ -661,8 +651,8 @@ final class DateTimeFormatterBuilder private(private val parent: DateTimeFormatt
     Objects.requireNonNull(textLookup, "textLookup")
     val copy: java.util.Map[Long, String] = new java.util.LinkedHashMap[Long, String](textLookup)
     val map: java.util.Map[TextStyle, java.util.Map[Long, String]] = Collections.singletonMap(TextStyle.FULL, copy)
-    val store: SimpleDateTimeTextProvider.LocaleStore = new SimpleDateTimeTextProvider.LocaleStore(map)
-    val provider: DateTimeTextProvider = new DateTimeTextProvider() {
+    val store: TTBPSimpleDateTimeTextProvider.LocaleStore = new TTBPSimpleDateTimeTextProvider.LocaleStore(map)
+    val provider: TTBPDateTimeTextProvider = new TTBPDateTimeTextProvider() {
       def getText(field: TemporalField, value: Long, style: TextStyle, locale: Locale): String = {
         store.getText(value, style)
       }

--- a/shared/src/main/scala/org/threeten/bp/format/internal/TTBPDateTimeFormatterBuilder.scala
+++ b/shared/src/main/scala/org/threeten/bp/format/internal/TTBPDateTimeFormatterBuilder.scala
@@ -3,6 +3,7 @@ package org.threeten.bp.format.internal
 import java.math.{BigDecimal, BigInteger, RoundingMode}
 import java.util._
 import java.lang.StringBuilder
+import java.lang.Long
 
 import org.threeten.bp._
 import org.threeten.bp.chrono.{ChronoLocalDate, Chronology}
@@ -358,7 +359,7 @@ object TTBPDateTimeFormatterBuilder {
         return false
       val value: Long = getValue(context, valueLong)
       val symbols: DecimalStyle = context.getSymbols
-      var str: String = if (value == Long.MinValue) "9223372036854775808" else Math.abs(value).toString
+      var str: String = if (value == scala.Long.MinValue) "9223372036854775808" else Math.abs(value).toString
       if (str.length > maxWidth)
         throw new DateTimeException(s"Field $field cannot be printed as the value $value exceeds the maximum print width of $maxWidth")
       str = symbols.convertNumberToI18N(str)
@@ -796,7 +797,7 @@ object TTBPDateTimeFormatterBuilder {
     * @param textStyle  the text style, not null
     * @param provider  the text provider, not null
     */
-  private[format] final class TextPrinterParser private[format](private val field: TemporalField, private val textStyle: TextStyle, private val provider: DateTimeTextProvider) extends DateTimePrinterParser {
+  private[format] final class TextPrinterParser private[format](private val field: TemporalField, private val textStyle: TextStyle, private val provider: TTBPDateTimeTextProvider) extends DateTimePrinterParser {
     /** The cached number printer parser.
       * Immutable and volatile, so no synchronization needed.
       */

--- a/shared/src/main/scala/org/threeten/bp/format/internal/TTBPDateTimeFormatterBuilder.scala
+++ b/shared/src/main/scala/org/threeten/bp/format/internal/TTBPDateTimeFormatterBuilder.scala
@@ -15,9 +15,6 @@ import org.threeten.bp.zone.ZoneRulesProvider
 
 import scala.annotation.tailrec
 
-/**
-  * Created by cquiroz on 4/25/17.
-  */
 object TTBPDateTimeFormatterBuilder {
   /** Strategy for printing/parsing date-time information.
     *

--- a/shared/src/main/scala/org/threeten/bp/format/internal/TTBPDateTimeTextProvider.scala
+++ b/shared/src/main/scala/org/threeten/bp/format/internal/TTBPDateTimeTextProvider.scala
@@ -29,17 +29,19 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.threeten.bp.format
+package org.threeten.bp.format.internal
 
 import java.util.Locale
+import java.lang.Long
 import org.threeten.bp.temporal.TemporalField
+import org.threeten.bp.format.TextStyle
 
-private[format] object DateTimeTextProvider {
+private[format] object TTBPDateTimeTextProvider {
   /** Gets the provider.
     *
     * @return the provider, not null
     */
-  private[format] def getInstance: DateTimeTextProvider = new SimpleDateTimeTextProvider
+  private[format] def getInstance: TTBPDateTimeTextProvider = new TTBPSimpleDateTimeTextProvider
 }
 
 /** The Service Provider Interface (SPI) to be implemented by classes providing
@@ -50,8 +52,8 @@ private[format] object DateTimeTextProvider {
   * Implementations must be thread-safe.
   * Implementations should cache the textual information.
   */
-abstract class DateTimeTextProvider {
-  /** Gets the available locales.
+abstract class TTBPDateTimeTextProvider {
+  /** Gets the availabte locales.
     *
     * @return the locales
     */

--- a/shared/src/main/scala/org/threeten/bp/format/internal/TTBPSimpleDateTimeTextProvider.scala
+++ b/shared/src/main/scala/org/threeten/bp/format/internal/TTBPSimpleDateTimeTextProvider.scala
@@ -29,7 +29,7 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.threeten.bp.format
+package org.threeten.bp.format.internal
 
 import org.threeten.bp.temporal.ChronoField.AMPM_OF_DAY
 import org.threeten.bp.temporal.ChronoField.DAY_OF_WEEK
@@ -42,11 +42,13 @@ import java.util.GregorianCalendar
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
+import java.lang.Long
 
 import org.threeten.bp.temporal.IsoFields
 import org.threeten.bp.temporal.TemporalField
+import org.threeten.bp.format.TextStyle
 
-private object SimpleDateTimeTextProvider {
+object TTBPSimpleDateTimeTextProvider {
   /** Cache. */
   private val CACHE: ConcurrentMap[java.util.Map.Entry[TemporalField, Locale], AnyRef] =
     new ConcurrentHashMap[java.util.Map.Entry[TemporalField, Locale], AnyRef](16, 0.75f, 2)
@@ -66,12 +68,12 @@ private object SimpleDateTimeTextProvider {
   private def createEntry[A, B](text: A, field: B): java.util.Map.Entry[A, B] =
     new java.util.AbstractMap.SimpleImmutableEntry[A, B](text, field)
 
-  private def createLocaleStore(valueTextMap: java.util.Map[TextStyle, java.util.Map[Long, String]]): SimpleDateTimeTextProvider.LocaleStore = {
+  private def createLocaleStore(valueTextMap: java.util.Map[TextStyle, java.util.Map[Long, String]]): TTBPSimpleDateTimeTextProvider.LocaleStore = {
     valueTextMap.put(TextStyle.FULL_STANDALONE, valueTextMap.get(TextStyle.FULL))
     valueTextMap.put(TextStyle.SHORT_STANDALONE, valueTextMap.get(TextStyle.SHORT))
     if (valueTextMap.containsKey(TextStyle.NARROW) && !valueTextMap.containsKey(TextStyle.NARROW_STANDALONE))
       valueTextMap.put(TextStyle.NARROW_STANDALONE, valueTextMap.get(TextStyle.NARROW))
-    new SimpleDateTimeTextProvider.LocaleStore(valueTextMap)
+    new TTBPSimpleDateTimeTextProvider.LocaleStore(valueTextMap)
   }
 
   /** Stores the text for a single locale.
@@ -147,33 +149,33 @@ private object SimpleDateTimeTextProvider {
   * <h3>Specification for implementors</h3>
   * This class is immutable and thread-safe.
   */
-final class SimpleDateTimeTextProvider extends DateTimeTextProvider {
+final class TTBPSimpleDateTimeTextProvider extends TTBPDateTimeTextProvider {
   /** {@inheritDoc} */
   override def getAvailableLocales: Array[Locale] = DateFormatSymbols.getAvailableLocales
 
-  def getText(field: TemporalField, value: Long, style: TextStyle, locale: Locale): String = {
+  override def getText(field: TemporalField, value: Long, style: TextStyle, locale: Locale): String = {
     val store: AnyRef = findStore(field, locale)
-    if (store.isInstanceOf[SimpleDateTimeTextProvider.LocaleStore])
-      store.asInstanceOf[SimpleDateTimeTextProvider.LocaleStore].getText(value, style)
+    if (store.isInstanceOf[TTBPSimpleDateTimeTextProvider.LocaleStore])
+      store.asInstanceOf[TTBPSimpleDateTimeTextProvider.LocaleStore].getText(value, style)
     else
       null
   }
 
-  def getTextIterator(field: TemporalField, style: TextStyle, locale: Locale): java.util.Iterator[java.util.Map.Entry[String, Long]] = {
+  override def getTextIterator(field: TemporalField, style: TextStyle, locale: Locale): java.util.Iterator[java.util.Map.Entry[String, Long]] = {
     val store: AnyRef = findStore(field, locale)
-    if (store.isInstanceOf[SimpleDateTimeTextProvider.LocaleStore])
-      store.asInstanceOf[SimpleDateTimeTextProvider.LocaleStore].getTextIterator(style)
+    if (store.isInstanceOf[TTBPSimpleDateTimeTextProvider.LocaleStore])
+      store.asInstanceOf[TTBPSimpleDateTimeTextProvider.LocaleStore].getTextIterator(style)
     else
       null
   }
 
   private def findStore(field: TemporalField, locale: Locale): AnyRef = {
-    val key: java.util.Map.Entry[TemporalField, Locale] = SimpleDateTimeTextProvider.createEntry(field, locale)
-    var store: AnyRef = SimpleDateTimeTextProvider.CACHE.get(key)
+    val key: java.util.Map.Entry[TemporalField, Locale] = TTBPSimpleDateTimeTextProvider.createEntry(field, locale)
+    var store: AnyRef = TTBPSimpleDateTimeTextProvider.CACHE.get(key)
     if (store == null) {
       store = createStore(field, locale)
-      SimpleDateTimeTextProvider.CACHE.putIfAbsent(key, store)
-      store = SimpleDateTimeTextProvider.CACHE.get(key)
+      TTBPSimpleDateTimeTextProvider.CACHE.putIfAbsent(key, store)
+      store = TTBPSimpleDateTimeTextProvider.CACHE.get(key)
     }
     store
   }
@@ -238,7 +240,7 @@ final class SimpleDateTimeTextProvider extends DateTimeTextProvider {
       map.put(f11, array(Calendar.NOVEMBER))
       map.put(f12, array(Calendar.DECEMBER))
       styleMap.put(TextStyle.SHORT, map)
-      return SimpleDateTimeTextProvider.createLocaleStore(styleMap)
+      return TTBPSimpleDateTimeTextProvider.createLocaleStore(styleMap)
     }
     if (field eq DAY_OF_WEEK) {
       val oldSymbols: DateFormatSymbols = DateFormatSymbols.getInstance(locale)
@@ -279,7 +281,7 @@ final class SimpleDateTimeTextProvider extends DateTimeTextProvider {
       map.put(f6, array(Calendar.SATURDAY))
       map.put(f7, array(Calendar.SUNDAY))
       styleMap.put(TextStyle.SHORT, map)
-      return SimpleDateTimeTextProvider.createLocaleStore(styleMap)
+      return TTBPSimpleDateTimeTextProvider.createLocaleStore(styleMap)
     }
     if (field eq AMPM_OF_DAY) {
       val oldSymbols: DateFormatSymbols = DateFormatSymbols.getInstance(locale)
@@ -290,7 +292,7 @@ final class SimpleDateTimeTextProvider extends DateTimeTextProvider {
       map.put(1L, array(Calendar.PM))
       styleMap.put(TextStyle.FULL, map)
       styleMap.put(TextStyle.SHORT, map)
-      return SimpleDateTimeTextProvider.createLocaleStore(styleMap)
+      return TTBPSimpleDateTimeTextProvider.createLocaleStore(styleMap)
     }
     if (field eq ERA) {
       val oldSymbols: DateFormatSymbols = DateFormatSymbols.getInstance(locale)
@@ -313,7 +315,7 @@ final class SimpleDateTimeTextProvider extends DateTimeTextProvider {
       map.put(0L, array(GregorianCalendar.BC).substring(0, 1))
       map.put(1L, array(GregorianCalendar.AD).substring(0, 1))
       styleMap.put(TextStyle.NARROW, map)
-      return SimpleDateTimeTextProvider.createLocaleStore(styleMap)
+      return TTBPSimpleDateTimeTextProvider.createLocaleStore(styleMap)
     }
     if (field eq IsoFields.QUARTER_OF_YEAR) {
       val styleMap: java.util.Map[TextStyle, java.util.Map[Long, String]] = new java.util.HashMap[TextStyle, java.util.Map[Long, String]]
@@ -329,7 +331,7 @@ final class SimpleDateTimeTextProvider extends DateTimeTextProvider {
       map.put(3L, "3rd quarter")
       map.put(4L, "4th quarter")
       styleMap.put(TextStyle.FULL, map)
-      return SimpleDateTimeTextProvider.createLocaleStore(styleMap)
+      return TTBPSimpleDateTimeTextProvider.createLocaleStore(styleMap)
     }
     ""
   }

--- a/shared/src/test/scala/org/threeten/bp/TestZonedDateTime.scala
+++ b/shared/src/test/scala/org/threeten/bp/TestZonedDateTime.scala
@@ -80,6 +80,8 @@ import org.threeten.bp.temporal.TemporalAdjuster
 import org.threeten.bp.temporal.TemporalField
 import org.threeten.bp.temporal.TemporalQueries
 import org.threeten.bp.temporal.TemporalQuery
+import org.threeten.bp.temporal.ValueRange
+import org.threeten.bp.temporal.UnsupportedTemporalTypeException
 
 /** Test ZonedDateTime. */
 object TestZonedDateTime {
@@ -578,8 +580,18 @@ class TestZonedDateTime extends FunSuite with GenDateTimeTest with AssertionsHel
         if (query eq TemporalQueries.zoneId) {
           return TEST_DATE_TIME_PARIS.getZone.asInstanceOf[R]
         }
-        super.query(query)
+        query.queryFrom(this)
       }
+
+      override def get(field: TemporalField): Int = range(field).checkValidIntValue(getLong(field), field)
+
+      override def range(field: TemporalField): ValueRange =
+        if (field.isInstanceOf[ChronoField])
+          if (isSupported(field)) field.range
+          else throw new UnsupportedTemporalTypeException(s"Unsupported field: $field")
+        else
+          field.rangeRefinedBy(this)
+
     }), TEST_DATE_TIME_PARIS)
   }
 
@@ -597,8 +609,17 @@ class TestZonedDateTime extends FunSuite with GenDateTimeTest with AssertionsHel
         if (query eq TemporalQueries.zoneId) {
           return TEST_DATE_TIME_PARIS.getZone.asInstanceOf[R]
         }
-        super.query(query)
+        query.queryFrom(this)
       }
+
+      override def get(field: TemporalField): Int = range(field).checkValidIntValue(getLong(field), field)
+
+      override def range(field: TemporalField): ValueRange =
+        if (field.isInstanceOf[ChronoField])
+          if (isSupported(field)) field.range
+          else throw new UnsupportedTemporalTypeException(s"Unsupported field: $field")
+        else
+          field.rangeRefinedBy(this)
     }), TEST_DATE_TIME_PARIS)
   }
 

--- a/shared/src/test/scala/org/threeten/bp/format/TestDateTimeTextPrinting.scala
+++ b/shared/src/test/scala/org/threeten/bp/format/TestDateTimeTextPrinting.scala
@@ -32,6 +32,7 @@
 package org.threeten.bp.format
 
 import java.util.Locale
+import java.lang.Long
 
 import org.scalatest.{BeforeAndAfter, FunSuite}
 import org.threeten.bp.{AssertionsHelper, LocalDateTime, Month}

--- a/shared/src/test/scala/org/threeten/bp/format/TestSimpleDateTimeTextProvider.scala
+++ b/shared/src/test/scala/org/threeten/bp/format/TestSimpleDateTimeTextProvider.scala
@@ -32,44 +32,47 @@
 package org.threeten.bp.format
 
 import java.util.Locale
+import java.lang.Long
 
 import org.scalatest.FunSuite
 import org.threeten.bp.AssertionsHelper
 import org.threeten.bp.Platform
 import org.threeten.bp.temporal.ChronoField.{AMPM_OF_DAY, DAY_OF_WEEK, MONTH_OF_YEAR}
 import org.threeten.bp.temporal.{ChronoField, TemporalField}
+import org.threeten.bp.format.internal.TTBPSimpleDateTimeTextProvider
+import org.threeten.bp.format.internal.TTBPDateTimeTextProvider
 
-/** Test SimpleDateTimeTextProvider. */
-class TestSimpleDateTimeTextProvider extends FunSuite with AssertionsHelper {
+/** Test TTBPSimpleDateTimeTextProvider. */
+class TestTTBPSimpleDateTimeTextProvider extends FunSuite with AssertionsHelper {
   private val enUS: Locale = new Locale("en", "US")
   private val ptBR: Locale = new Locale("pt", "BR")
   private val frFR: Locale = new Locale("fr", "FR")
 
-  def data_text: List[List[Any]] =
-    List[List[Any]](
-      List(DAY_OF_WEEK, 1, TextStyle.SHORT, enUS, "Mon"), List(DAY_OF_WEEK, 2, TextStyle.SHORT, enUS, "Tue"), List(DAY_OF_WEEK, 3, TextStyle.SHORT, enUS, "Wed"), List(DAY_OF_WEEK, 4, TextStyle.SHORT, enUS, "Thu"), List(DAY_OF_WEEK, 5, TextStyle.SHORT, enUS, "Fri"), List(DAY_OF_WEEK, 6, TextStyle.SHORT, enUS, "Sat"), List(DAY_OF_WEEK, 7, TextStyle.SHORT, enUS, "Sun"),
-      List(DAY_OF_WEEK, 1, TextStyle.SHORT, ptBR, "Seg"), List(DAY_OF_WEEK, 2, TextStyle.SHORT, ptBR, "Ter"), List(DAY_OF_WEEK, 3, TextStyle.SHORT, ptBR, "Qua"), List(DAY_OF_WEEK, 4, TextStyle.SHORT, ptBR, "Qui"), List(DAY_OF_WEEK, 5, TextStyle.SHORT, ptBR, "Sex"), List(DAY_OF_WEEK, 6, TextStyle.SHORT, ptBR, "S\u00E1b"), List(DAY_OF_WEEK, 7, TextStyle.SHORT, ptBR, "Dom"),
-      List(DAY_OF_WEEK, 1, TextStyle.FULL, enUS, "Monday"), List(DAY_OF_WEEK, 2, TextStyle.FULL, enUS, "Tuesday"), List(DAY_OF_WEEK, 3, TextStyle.FULL, enUS, "Wednesday"), List(DAY_OF_WEEK, 4, TextStyle.FULL, enUS, "Thursday"), List(DAY_OF_WEEK, 5, TextStyle.FULL, enUS, "Friday"), List(DAY_OF_WEEK, 6, TextStyle.FULL, enUS, "Saturday"), List(DAY_OF_WEEK, 7, TextStyle.FULL, enUS, "Sunday"),
-      List(DAY_OF_WEEK, 1, TextStyle.FULL, ptBR, "Segunda-feira"), List(DAY_OF_WEEK, 2, TextStyle.FULL, ptBR, "Ter\u00E7a-feira"), List(DAY_OF_WEEK, 3, TextStyle.FULL, ptBR, "Quarta-feira"), List(DAY_OF_WEEK, 4, TextStyle.FULL, ptBR, "Quinta-feira"), List(DAY_OF_WEEK, 5, TextStyle.FULL, ptBR, "Sexta-feira"), List(DAY_OF_WEEK, 6, TextStyle.FULL, ptBR, "S\u00E1bado"), List(DAY_OF_WEEK, 7, TextStyle.FULL, ptBR, "Domingo"),
-      List(MONTH_OF_YEAR, 1, TextStyle.SHORT, enUS, "Jan"), List(MONTH_OF_YEAR, 2, TextStyle.SHORT, enUS, "Feb"), List(MONTH_OF_YEAR, 3, TextStyle.SHORT, enUS, "Mar"), List(MONTH_OF_YEAR, 4, TextStyle.SHORT, enUS, "Apr"), List(MONTH_OF_YEAR, 5, TextStyle.SHORT, enUS, "May"), List(MONTH_OF_YEAR, 6, TextStyle.SHORT, enUS, "Jun"), List(MONTH_OF_YEAR, 7, TextStyle.SHORT, enUS, "Jul"), List(MONTH_OF_YEAR, 8, TextStyle.SHORT, enUS, "Aug"), List(MONTH_OF_YEAR, 9, TextStyle.SHORT, enUS, "Sep"), List(MONTH_OF_YEAR, 10, TextStyle.SHORT, enUS, "Oct"), List(MONTH_OF_YEAR, 11, TextStyle.SHORT, enUS, "Nov"), List(MONTH_OF_YEAR, 12, TextStyle.SHORT, enUS, "Dec"),
-      List(MONTH_OF_YEAR, 1, TextStyle.SHORT, frFR, "janv."), List(MONTH_OF_YEAR, 2, TextStyle.SHORT, frFR, "f\u00E9vr."), List(MONTH_OF_YEAR, 3, TextStyle.SHORT, frFR, "mars"), List(MONTH_OF_YEAR, 4, TextStyle.SHORT, frFR, "avr."), List(MONTH_OF_YEAR, 5, TextStyle.SHORT, frFR, "mai"), List(MONTH_OF_YEAR, 6, TextStyle.SHORT, frFR, "juin"), List(MONTH_OF_YEAR, 7, TextStyle.SHORT, frFR, "juil."), List(MONTH_OF_YEAR, 8, TextStyle.SHORT, frFR, "ao\u00FBt"), List(MONTH_OF_YEAR, 9, TextStyle.SHORT, frFR, "sept."), List(MONTH_OF_YEAR, 10, TextStyle.SHORT, frFR, "oct."), List(MONTH_OF_YEAR, 11, TextStyle.SHORT, frFR, "nov."), List(MONTH_OF_YEAR, 12, TextStyle.SHORT, frFR, "d\u00E9c."),
-      List(MONTH_OF_YEAR, 1, TextStyle.FULL, enUS, "January"), List(MONTH_OF_YEAR, 2, TextStyle.FULL, enUS, "February"), List(MONTH_OF_YEAR, 3, TextStyle.FULL, enUS, "March"), List(MONTH_OF_YEAR, 4, TextStyle.FULL, enUS, "April"), List(MONTH_OF_YEAR, 5, TextStyle.FULL, enUS, "May"), List(MONTH_OF_YEAR, 6, TextStyle.FULL, enUS, "June"), List(MONTH_OF_YEAR, 7, TextStyle.FULL, enUS, "July"), List(MONTH_OF_YEAR, 8, TextStyle.FULL, enUS, "August"), List(MONTH_OF_YEAR, 9, TextStyle.FULL, enUS, "September"), List(MONTH_OF_YEAR, 10, TextStyle.FULL, enUS, "October"), List(MONTH_OF_YEAR, 11, TextStyle.FULL, enUS, "November"), List(MONTH_OF_YEAR, 12, TextStyle.FULL, enUS, "December"),
-      List(MONTH_OF_YEAR, 1, TextStyle.FULL, ptBR, "Janeiro"), List(MONTH_OF_YEAR, 2, TextStyle.FULL, ptBR, "Fevereiro"), List(MONTH_OF_YEAR, 3, TextStyle.FULL, ptBR, "Mar\u00E7o"), List(MONTH_OF_YEAR, 4, TextStyle.FULL, ptBR, "Abril"), List(MONTH_OF_YEAR, 5, TextStyle.FULL, ptBR, "Maio"), List(MONTH_OF_YEAR, 6, TextStyle.FULL, ptBR, "Junho"), List(MONTH_OF_YEAR, 7, TextStyle.FULL, ptBR, "Julho"), List(MONTH_OF_YEAR, 8, TextStyle.FULL, ptBR, "Agosto"), List(MONTH_OF_YEAR, 9, TextStyle.FULL, ptBR, "Setembro"), List(MONTH_OF_YEAR, 10, TextStyle.FULL, ptBR, "Outubro"), List(MONTH_OF_YEAR, 11, TextStyle.FULL, ptBR, "Novembro"), List(MONTH_OF_YEAR, 12, TextStyle.FULL, ptBR, "Dezembro"),
-      List(AMPM_OF_DAY, 0, TextStyle.SHORT, enUS, "AM"), List(AMPM_OF_DAY, 1, TextStyle.SHORT, enUS, "PM"))
+  def data_text: List[(TemporalField, Long, TextStyle, Locale, String)] =
+    List(
+      (DAY_OF_WEEK, 1, TextStyle.SHORT, enUS, "Mon"), (DAY_OF_WEEK, 2, TextStyle.SHORT, enUS, "Tue"), (DAY_OF_WEEK, 3, TextStyle.SHORT, enUS, "Wed"), (DAY_OF_WEEK, 4, TextStyle.SHORT, enUS, "Thu"), (DAY_OF_WEEK, 5, TextStyle.SHORT, enUS, "Fri"), (DAY_OF_WEEK, 6, TextStyle.SHORT, enUS, "Sat"), (DAY_OF_WEEK, 7, TextStyle.SHORT, enUS, "Sun"),
+      (DAY_OF_WEEK, 1, TextStyle.SHORT, ptBR, "Seg"), (DAY_OF_WEEK, 2, TextStyle.SHORT, ptBR, "Ter"), (DAY_OF_WEEK, 3, TextStyle.SHORT, ptBR, "Qua"), (DAY_OF_WEEK, 4, TextStyle.SHORT, ptBR, "Qui"), (DAY_OF_WEEK, 5, TextStyle.SHORT, ptBR, "Sex"), (DAY_OF_WEEK, 6, TextStyle.SHORT, ptBR, "S\u00E1b"), (DAY_OF_WEEK, 7, TextStyle.SHORT, ptBR, "Dom"),
+      (DAY_OF_WEEK, 1, TextStyle.FULL, enUS, "Monday"), (DAY_OF_WEEK, 2, TextStyle.FULL, enUS, "Tuesday"), (DAY_OF_WEEK, 3, TextStyle.FULL, enUS, "Wednesday"), (DAY_OF_WEEK, 4, TextStyle.FULL, enUS, "Thursday"), (DAY_OF_WEEK, 5, TextStyle.FULL, enUS, "Friday"), (DAY_OF_WEEK, 6, TextStyle.FULL, enUS, "Saturday"), (DAY_OF_WEEK, 7, TextStyle.FULL, enUS, "Sunday"),
+      (DAY_OF_WEEK, 1, TextStyle.FULL, ptBR, "Segunda-feira"), (DAY_OF_WEEK, 2, TextStyle.FULL, ptBR, "Ter\u00E7a-feira"), (DAY_OF_WEEK, 3, TextStyle.FULL, ptBR, "Quarta-feira"), (DAY_OF_WEEK, 4, TextStyle.FULL, ptBR, "Quinta-feira"), (DAY_OF_WEEK, 5, TextStyle.FULL, ptBR, "Sexta-feira"), (DAY_OF_WEEK, 6, TextStyle.FULL, ptBR, "S\u00E1bado"), (DAY_OF_WEEK, 7, TextStyle.FULL, ptBR, "Domingo"),
+      (MONTH_OF_YEAR, 1, TextStyle.SHORT, enUS, "Jan"), (MONTH_OF_YEAR, 2, TextStyle.SHORT, enUS, "Feb"), (MONTH_OF_YEAR, 3, TextStyle.SHORT, enUS, "Mar"), (MONTH_OF_YEAR, 4, TextStyle.SHORT, enUS, "Apr"), (MONTH_OF_YEAR, 5, TextStyle.SHORT, enUS, "May"), (MONTH_OF_YEAR, 6, TextStyle.SHORT, enUS, "Jun"), (MONTH_OF_YEAR, 7, TextStyle.SHORT, enUS, "Jul"), (MONTH_OF_YEAR, 8, TextStyle.SHORT, enUS, "Aug"), (MONTH_OF_YEAR, 9, TextStyle.SHORT, enUS, "Sep"), (MONTH_OF_YEAR, 10, TextStyle.SHORT, enUS, "Oct"), (MONTH_OF_YEAR, 11, TextStyle.SHORT, enUS, "Nov"), (MONTH_OF_YEAR, 12, TextStyle.SHORT, enUS, "Dec"),
+      (MONTH_OF_YEAR, 1, TextStyle.SHORT, frFR, "janv."), (MONTH_OF_YEAR, 2, TextStyle.SHORT, frFR, "f\u00E9vr."), (MONTH_OF_YEAR, 3, TextStyle.SHORT, frFR, "mars"), (MONTH_OF_YEAR, 4, TextStyle.SHORT, frFR, "avr."), (MONTH_OF_YEAR, 5, TextStyle.SHORT, frFR, "mai"), (MONTH_OF_YEAR, 6, TextStyle.SHORT, frFR, "juin"), (MONTH_OF_YEAR, 7, TextStyle.SHORT, frFR, "juil."), (MONTH_OF_YEAR, 8, TextStyle.SHORT, frFR, "ao\u00FBt"), (MONTH_OF_YEAR, 9, TextStyle.SHORT, frFR, "sept."), (MONTH_OF_YEAR, 10, TextStyle.SHORT, frFR, "oct."), (MONTH_OF_YEAR, 11, TextStyle.SHORT, frFR, "nov."), (MONTH_OF_YEAR, 12, TextStyle.SHORT, frFR, "d\u00E9c."),
+      (MONTH_OF_YEAR, 1, TextStyle.FULL, enUS, "January"), (MONTH_OF_YEAR, 2, TextStyle.FULL, enUS, "February"), (MONTH_OF_YEAR, 3, TextStyle.FULL, enUS, "March"), (MONTH_OF_YEAR, 4, TextStyle.FULL, enUS, "April"), (MONTH_OF_YEAR, 5, TextStyle.FULL, enUS, "May"), (MONTH_OF_YEAR, 6, TextStyle.FULL, enUS, "June"), (MONTH_OF_YEAR, 7, TextStyle.FULL, enUS, "July"), (MONTH_OF_YEAR, 8, TextStyle.FULL, enUS, "August"), (MONTH_OF_YEAR, 9, TextStyle.FULL, enUS, "September"), (MONTH_OF_YEAR, 10, TextStyle.FULL, enUS, "October"), (MONTH_OF_YEAR, 11, TextStyle.FULL, enUS, "November"), (MONTH_OF_YEAR, 12, TextStyle.FULL, enUS, "December"),
+      (MONTH_OF_YEAR, 1, TextStyle.FULL, ptBR, "Janeiro"), (MONTH_OF_YEAR, 2, TextStyle.FULL, ptBR, "Fevereiro"), (MONTH_OF_YEAR, 3, TextStyle.FULL, ptBR, "Mar\u00E7o"), (MONTH_OF_YEAR, 4, TextStyle.FULL, ptBR, "Abril"), (MONTH_OF_YEAR, 5, TextStyle.FULL, ptBR, "Maio"), (MONTH_OF_YEAR, 6, TextStyle.FULL, ptBR, "Junho"), (MONTH_OF_YEAR, 7, TextStyle.FULL, ptBR, "Julho"), (MONTH_OF_YEAR, 8, TextStyle.FULL, ptBR, "Agosto"), (MONTH_OF_YEAR, 9, TextStyle.FULL, ptBR, "Setembro"), (MONTH_OF_YEAR, 10, TextStyle.FULL, ptBR, "Outubro"), (MONTH_OF_YEAR, 11, TextStyle.FULL, ptBR, "Novembro"), (MONTH_OF_YEAR, 12, TextStyle.FULL, ptBR, "Dezembro"),
+      (AMPM_OF_DAY, 0, TextStyle.SHORT, enUS, "AM"), (AMPM_OF_DAY, 1, TextStyle.SHORT, enUS, "PM"))
 
   test("getText") {
     data_text.foreach {
-      case (field: TemporalField) :: (value: Number) :: (style: TextStyle) :: (locale: Locale) :: (expected: String) :: Nil =>
+      case (field, value, style, locale, expected) =>
         Platform.setupLocales()
-        val tp: DateTimeTextProvider = DateTimeTextProvider.getInstance
+        val tp: TTBPDateTimeTextProvider = TTBPDateTimeTextProvider.getInstance
 
         // Work around difference between JRE locale data and CLDR data:
         // JRE specifies capitalized brazilian month and day-of-week names,
         // while CLDR specifies lower-cased names.
         if (locale == ptBR && (field == ChronoField.MONTH_OF_YEAR || field == ChronoField.DAY_OF_WEEK))
-          assertEquals(tp.getText(field, value.longValue, style, locale).capitalize, expected)
+          assertEquals(tp.getText(field, value, style, locale).capitalize, expected)
         else
-          assertEquals(tp.getText(field, value.longValue, style, locale), expected)
+          assertEquals(tp.getText(field, value, style, locale), expected)
       case _ =>
         fail()
     }

--- a/shared/src/test/scala/org/threeten/bp/format/TestTextParser.scala
+++ b/shared/src/test/scala/org/threeten/bp/format/TestTextParser.scala
@@ -41,10 +41,11 @@ import java.util.Locale
 import org.threeten.bp.temporal.TemporalField
 import org.threeten.bp.temporal.TemporalQueries
 import org.threeten.bp.format.internal.{TTBPDateTimeFormatterBuilder, TTBPDateTimeParseContext}
+import org.threeten.bp.format.internal.TTBPDateTimeTextProvider
 
 /** Test TextPrinterParser. */
 object TestTextParser {
-  private val PROVIDER: DateTimeTextProvider = DateTimeTextProvider.getInstance
+  private val PROVIDER: TTBPDateTimeTextProvider = TTBPDateTimeTextProvider.getInstance
 }
 
 class TestTextParser extends FunSuite with GenTestPrinterParser with AssertionsHelper {

--- a/shared/src/test/scala/org/threeten/bp/format/TestTextPrinter.scala
+++ b/shared/src/test/scala/org/threeten/bp/format/TestTextPrinter.scala
@@ -41,12 +41,13 @@ import org.threeten.bp.AssertionsHelper
 import org.threeten.bp.DateTimeException
 import org.threeten.bp.LocalDate
 import org.threeten.bp.format.internal.TTBPDateTimeFormatterBuilder
+import org.threeten.bp.format.internal.TTBPDateTimeTextProvider
 import org.threeten.bp.temporal.MockFieldValue
 import org.threeten.bp.temporal.TemporalField
 
 /** Test TextPrinterParser. */
 object TestTextPrinter {
-  private val PROVIDER: DateTimeTextProvider = DateTimeTextProvider.getInstance
+  private val PROVIDER: TTBPDateTimeTextProvider = TTBPDateTimeTextProvider.getInstance
 }
 
 class TestTextPrinter extends FunSuite with GenTestPrinterParser with AssertionsHelper {


### PR DESCRIPTION
The tests for `DateTimeTextPrinting` and `ZonedDateTime` were commented due to some compilation failures. This PR restores those tests fixing some incompatibilities with the original API due to the use of the scala `Long` class in some places