### PR TITLE
Support building on scala.js 1.0.0-M2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import sbtcrossproject.{crossProject, CrossType}
 import sbt._
 import sbt.io.Using
 import TZDBTasks._
@@ -56,9 +57,15 @@ lazy val commonSettings = Seq(
     },
   pomExtra := pomData,
   pomIncludeRepository := { _ => false },
-  libraryDependencies ++= Seq(
-    "org.scalatest" %%% "scalatest" % "3.0.4" % "test"
-  )
+  libraryDependencies ++= {
+    if (scalaJSVersion.startsWith("0.6.")) {
+      Seq(
+        "org.scalatest" %%% "scalatest" % "3.0.4" % "test"
+      )
+    } else {
+      Nil
+    }
+  }
 )
 
 lazy val root = project.in(file("."))
@@ -141,7 +148,7 @@ def copyAndReplace(srcDirs: Seq[File], destinationDir: File): Seq[File] = {
   generatedFiles
 }
 
-lazy val scalajavatime = crossProject.crossType(CrossType.Full).in(file("."))
+lazy val scalajavatime = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Full).in(file("."))
   .settings(commonSettings: _*)
   .jvmSettings(
     resolvers += Resolver.sbtPluginRepo("releases"),
@@ -176,7 +183,7 @@ lazy val scalajavatime = crossProject.crossType(CrossType.Full).in(file("."))
       }.taskValue,
     parallelExecution in Test := false,
     libraryDependencies ++= Seq(
-      "io.github.cquiroz" %%% "scala-java-locales" % "0.3.5-cldr31"
+      "io.github.cquiroz" %%% "scala-java-locales" % "0.3.9-cldr32"
     )
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,6 @@ import sbt.Keys._
 
 resolvers += Resolver.sonatypeRepo("public")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")
-
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")
 
 addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.7.10")
@@ -11,6 +9,15 @@ addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.7.10")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+
+val scalaJSVersion =
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.21")
+
+addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "0.3.0")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.3.0")
 
 // Incompatible with 2.12.0-M5
 // addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")


### PR DESCRIPTION
Though we can't test in 1.0.0-M2 we should be able to do a release nonetheless