### PR TITLE
Only java packages on export

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Both Scala 2.11 and Scala 2.12 (2.12.0-M7 and later) are supported.
 
 To get started with SBT, add one (or both) of these dependencies:
 
-- `libraryDependencies += "io.github.cquiroz" %%  "scala-java-time" % "2.0.0-M12"` (for Scala)
-- `libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-M12` (for Scala.js, [Scala.js plugin](http://www.scala-js.org/tutorial/basic/#sbt-setup) required)
+- `libraryDependencies += "io.github.cquiroz" %%  "scala-java-time" % "2.0.0-M13"` (for Scala)
+- `libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-M13` (for Scala.js, [Scala.js plugin](http://www.scala-js.org/tutorial/basic/#sbt-setup) required)
 
 #### Documentation
 

--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,8 @@ lazy val commonSettings = Seq(
     "-feature",
     "-encoding", "UTF-8",
   ),
+  // Don't include threeten on the binaries
+  mappings in (Compile, packageBin) := (mappings in (Compile, packageBin)).value.filter { case (f, s) => !s.contains("semanticdb") && !s.contains("threeten") },
   scalacOptions := {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>

--- a/changes.xml
+++ b/changes.xml
@@ -9,7 +9,7 @@
   </properties>
   <body>
     <!-- types are add, fix, remove, update -->
-    <release version="2.0.0-M13" date="2017-12-23" description="v2.0.0-13">
+    <release version="2.0.0-M13" date="2018-02-21" description="v2.0.0-13">
       <action dev="cquiroz" type="update" >
         Update to scala.js 0.6.22
       </action>
@@ -29,6 +29,9 @@
       </action>
       <action dev="cquiroz" type="update" >
         Use sbt-tzdb to build the timezone db
+      </action>
+      <action dev="cquiroz" type="update" >
+        Publish only the java.time package
       </action>
     </release>
     <release version="2.0.0-M12" date="2017-06-06" description="v2.0.0-M12">

--- a/core/js/src/main/scala/java/util/Calendar.scala
+++ b/core/js/src/main/scala/java/util/Calendar.scala
@@ -1,6 +1,6 @@
 package java.util
 
-import org.threeten.bp.Instant
+import java.time.Instant
 
 @SerialVersionUID(-1807547505821590642L)
 abstract class Calendar private[util](timezone: TimeZone = null, locale: Locale = null) extends Cloneable with Serializable with Ordered[Calendar] {

--- a/core/js/src/main/scala/java/util/GregorianCalendar.scala
+++ b/core/js/src/main/scala/java/util/GregorianCalendar.scala
@@ -1,6 +1,6 @@
 package java.util
 
-import org.threeten.bp.ZonedDateTime
+import java.time.ZonedDateTime
 
 @SerialVersionUID(-8125100834729963327L)
 class GregorianCalendar(timezone: TimeZone = TimeZone.getDefault, locale: Locale = Locale.getDefault) extends Calendar(timezone, locale) {

--- a/core/js/src/main/scala/java/util/TimeZone.scala
+++ b/core/js/src/main/scala/java/util/TimeZone.scala
@@ -2,8 +2,8 @@ package java.util
 
 import java.text.DateFormatSymbols
 
-import org.threeten.bp.{Instant, ZoneId}
-import org.threeten.bp.zone.ZoneRulesProvider
+import java.time.{Instant, ZoneId}
+import java.time.zone.ZoneRulesProvider
 
 import scala.collection.JavaConverters._
 import scala.util.Try

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -16,9 +16,7 @@ The implementation is based on the original BSD-licensed reference implementatio
 #### Example
 
 ```tut:book
-// On scala.js you can pick either java.time or org.threeten.bp package to import
-//import java.time._
-import org.threeten.bp._
+import java.time._
 
 // always returns 2009-02-13T23:31:30
 val fixedClock = Clock.fixed(Instant.ofEpochSecond(1234567890L), ZoneOffset.ofHours(0))
@@ -60,8 +58,8 @@ Both Scala 2.11 and Scala 2.12 (2.0.0-M8 and later) are supported.
 
 To get started with SBT, add one of these dependencies:
 
-* `libraryDependencies += "io.github.cquiroz" %% "scala-java-time" % "2.0.0-M12"` (for Scala)
-* `libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-M12"` (for Scala.js, [Scala.js plugin](http://www.scala-js.org/tutorial/basic/#sbt-setup) required)
+* `libraryDependencies += "io.github.cquiroz" %% "scala-java-time" % "2.0.0-M13"` (for Scala)
+* `libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-M13"` (for Scala.js, [Scala.js plugin](http://www.scala-js.org/tutorial/basic/#sbt-setup) required)
 
 To get the latest snapshots add the repo
 
@@ -72,8 +70,8 @@ resolvers +=
 
 and either:
 
-* `libraryDependencies += "io.github.cquiroz" %% "scala-java-time" % "2.0.0-M13-SNAPSHOT"` (for Scala)
-* `libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-M13-SNAPSHOT"` (for Scala.js, [Scala.js plugin](http://www.scala-js.org/tutorial/basic/#sbt-setup) required)
+* `libraryDependencies += "io.github.cquiroz" %% "scala-java-time" % "2.0.0-M14-SNAPSHOT"` (for Scala)
+* `libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-M14-SNAPSHOT"` (for Scala.js, [Scala.js plugin](http://www.scala-js.org/tutorial/basic/#sbt-setup) required)
 
 ### Time zones
 
@@ -86,7 +84,7 @@ If you don't need to use timezones in your application you can just stop here. B
 The timezone for js is provided in a separate bundle which contains all time zones available from
 [IANA Time Zone Database](https://www.iana.org/time-zones). To use them you need to add the following dependency
 
-* `libraryDependencies += "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.0.0-M13_2018c-SNAPSHOT"` (for Scala.js, [Scala.js plugin](http://www.scala-js.org/tutorial/basic/#sbt-setup) required)
+* `libraryDependencies += "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.0.0-M13_2018c"` (for Scala.js, [Scala.js plugin](http://www.scala-js.org/tutorial/basic/#sbt-setup) required)
 
 Note that the db is fairly large and due to the characteristics of the API it's not very ammenable to optimization
 This database is published every now and then so it maybe old. For current version see the following section.
@@ -103,7 +101,7 @@ To do that you need to:
 * Add `sbt-tzdb` to your list of plugins (Note you need sbt 1.x)
 
 ```scala
-addSbtPlugin("io.github.cquiroz" % "sbt-tzdb" % "0.1.1")
+addSbtPlugin("io.github.cquiroz" % "sbt-tzdb" % "0.1.2")
 ```
 
 * Enable the plugin for your `Scala.js` project:
@@ -156,11 +154,18 @@ Have a look at the [issues](https://github.com/cquiroz/scala-java-time/issues) o
 
 ##### 2.0
 
-The current version is published containing the code in both packages: `org.threeten.bp` and `java.time`.
-
 A stable release of 2.0 will be published with only `java.time` on its binary after a (hopefully) short RC phase.
 
 #### FAQs
+
+##### What's with the packages? the code uses `org.threeten.bp` but I use `java.time`
+
+The original code was in the `org.threeten.bp` and that has been maintained, among other reasons, because writing
+code on the `java` namespace tends to produce issues with the security controls of the JVM
+
+Thus the code is on `org.threeten.bp` but during packaging the code is moved to `java.time` and `org.threeten.bp` is removed.
+
+Most applications would use the `java.time` package mirroring the JVM
 
 ##### Is this project derived from OpenJDK?
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,7 +21,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.3.1")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.10")
 
-addSbtPlugin("io.github.cquiroz" % "sbt-tzdb" % "0.1.1")
+addSbtPlugin("io.github.cquiroz" % "sbt-tzdb" % "0.1.2")
 
 // Incompatible with 2.12.0-M5
 // addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")


### PR DESCRIPTION
This is the las PR for the M13 release.
It brings an important change. The binary will include only the java.time package

This reduces the size of the binary and speeds up compilation time for applications as there is less code to process

This assumes most people use `java.tima` rather than `org.threetrn` which is probably a good assumption 