### PR TITLE
Fix deprecation warning on crossProject plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import sbtcrossproject.{crossProject, CrossType}
+import sbtcrossproject.CrossPlugin.autoImport.{ crossProject, CrossType }
 import sbt._
 import sbt.io.Using
 


### PR DESCRIPTION
`sbtcrossproject.crossProject` is deprecated in favor of `sbtcrossproject.CrossPlugin.AutoImport`.
