### PR TITLE
Try sbt 1.3.0-RC1

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.3.0-RC1


### PR DESCRIPTION
https://www.lightbend.com/blog/sbt-1.3.0-release

sbt 1.3 introdues lots of enhancements.
Let's seethat scala-java-time works fine with sbt 1.3.0 or not. 