### PR TITLE
Fix travis fails to handle empty cache in .ivy after sbt 1.3.0-RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,5 +52,5 @@ script:
   # docs/makeMicrosite
   # Tricks to avoid unnecessary cache updates, from
   # http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html
-  - find $HOME/.sbt -name "*.lock" | xargs rm
-  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete


### PR DESCRIPTION
It seems that every build matrix fail after sbt 1.3.0-RC1.
https://travis-ci.org/exoego/scala-java-time/jobs/534310876#L685

This PR uses `find -delete` option to clear cache instead of `find | xargs rm` in case `rm` fails due to missing cache.
This is described in https://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html



