### PR TITLE
Remove the use of ConcurrentHashMap

### DIFF
--- a/core/shared/src/main/scala/org/threeten/bp/ZoneOffset.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/ZoneOffset.scala
@@ -39,8 +39,8 @@ import java.io.IOException
 import java.io.InvalidObjectException
 import java.io.ObjectStreamException
 import java.io.Serializable
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentMap
+import java.util.HashMap
+import java.util.Map
 import org.threeten.bp.temporal.ChronoField
 import org.threeten.bp.temporal.Temporal
 import org.threeten.bp.temporal.TemporalAccessor
@@ -56,12 +56,12 @@ import org.threeten.bp.zone.ZoneRules
 object ZoneOffset {
 
   /** Cache of time-zone offset by offset in seconds. */
-  private val SECONDS_CACHE: ConcurrentMap[Integer, ZoneOffset] =
-    new ConcurrentHashMap[Integer, ZoneOffset](16, 0.75f, 4)
+  private val SECONDS_CACHE: Map[Integer, ZoneOffset] =
+    new HashMap[Integer, ZoneOffset]()
 
   /** Cache of time-zone offset by ID. */
-  private val ID_CACHE: ConcurrentMap[String, ZoneOffset] =
-    new ConcurrentHashMap[String, ZoneOffset](16, 0.75f, 4)
+  private val ID_CACHE: Map[String, ZoneOffset] =
+    new HashMap[String, ZoneOffset]()
 
   /** The number of seconds per hour. */
   private val SECONDS_PER_HOUR: Int = 60 * 60
@@ -310,9 +310,9 @@ object ZoneOffset {
       var result: ZoneOffset = SECONDS_CACHE.get(totalSecs)
       if (result == null) {
         result = new ZoneOffset(totalSeconds)
-        SECONDS_CACHE.putIfAbsent(totalSecs, result)
+        SECONDS_CACHE.put(totalSecs, result)
         result = SECONDS_CACHE.get(totalSecs)
-        ID_CACHE.putIfAbsent(result.getId, result)
+        ID_CACHE.put(result.getId, result)
       }
       result
     } else

--- a/core/shared/src/main/scala/org/threeten/bp/chrono/Chronology.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/chrono/Chronology.scala
@@ -37,7 +37,8 @@ import java.io.IOException
 import java.io.InvalidObjectException
 import java.io.ObjectStreamException
 import java.util.{ Locale, Objects }
-import java.util.concurrent.ConcurrentHashMap
+import java.util.HashMap
+import java.util.Map
 
 import org.threeten.bp.Clock
 import org.threeten.bp.DateTimeException
@@ -60,12 +61,12 @@ import org.threeten.bp.temporal.ValueRange
 object Chronology {
 
   /** Map of available calendars by ID. */
-  private val CHRONOS_BY_ID: ConcurrentHashMap[String, Chronology] =
-    new ConcurrentHashMap[String, Chronology]
+  private val CHRONOS_BY_ID: Map[String, Chronology] =
+    new HashMap[String, Chronology]()
 
   /** Map of available calendars by calendar type. */
-  private val CHRONOS_BY_TYPE: ConcurrentHashMap[String, Chronology] =
-    new ConcurrentHashMap[String, Chronology]
+  private val CHRONOS_BY_TYPE: Map[String, Chronology] =
+    new HashMap[String, Chronology]()
 
   /** Obtains an instance of {@code Chronology} from a temporal object.
     *
@@ -189,24 +190,24 @@ object Chronology {
       register(MinguoChronology.INSTANCE)
       register(JapaneseChronology.INSTANCE)
       register(HijrahChronology.INSTANCE)
-      CHRONOS_BY_ID.putIfAbsent("Hijrah", HijrahChronology.INSTANCE)
-      CHRONOS_BY_TYPE.putIfAbsent("islamic", HijrahChronology.INSTANCE)
+      CHRONOS_BY_ID.put("Hijrah", HijrahChronology.INSTANCE)
+      CHRONOS_BY_TYPE.put("islamic", HijrahChronology.INSTANCE)
       val chronologies: java.util.Iterator[Chronology] =
         ChronologyPlatformHelper.loadAdditionalChronologies
       while (chronologies.hasNext) {
         val chrono = chronologies.next()
-        CHRONOS_BY_ID.putIfAbsent(chrono.getId, chrono)
+        CHRONOS_BY_ID.put(chrono.getId, chrono)
         val `type`: String = chrono.getCalendarType
         if (`type` != null)
-          CHRONOS_BY_TYPE.putIfAbsent(`type`, chrono)
+          CHRONOS_BY_TYPE.put(`type`, chrono)
       }
     }
 
   private def register(chrono: Chronology): Unit = {
-    CHRONOS_BY_ID.putIfAbsent(chrono.getId, chrono)
+    CHRONOS_BY_ID.put(chrono.getId, chrono)
     val `type`: String = chrono.getCalendarType
     if (`type` != null)
-      CHRONOS_BY_TYPE.putIfAbsent(`type`, chrono)
+      CHRONOS_BY_TYPE.put(`type`, chrono)
     ()
   }
 

--- a/core/shared/src/main/scala/org/threeten/bp/format/DecimalStyle.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/format/DecimalStyle.scala
@@ -33,8 +33,8 @@ package org.threeten.bp.format
 
 import java.text.DecimalFormatSymbols
 import java.util.{ Locale, Objects }
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentMap
+import java.util.HashMap
+import java.util.Map
 import scala.collection.JavaConverters._
 
 /** Localized symbols used in date and time formatting.
@@ -54,8 +54,8 @@ object DecimalStyle {
   val STANDARD: DecimalStyle = new DecimalStyle('0', '+', '-', '.')
 
   /** The cache of symbols instances. */
-  private val CACHE: ConcurrentMap[Locale, DecimalStyle] =
-    new ConcurrentHashMap[Locale, DecimalStyle](16, 0.75f, 2)
+  private val CACHE: Map[Locale, DecimalStyle] =
+    new HashMap[Locale, DecimalStyle]()
 
   /** Lists all the locales that are supported.
     *
@@ -85,7 +85,7 @@ object DecimalStyle {
     Objects.requireNonNull(locale, "locale")
     // Size reduced
     if (CACHE.get(locale) == null) {
-      CACHE.putIfAbsent(locale, create(locale))
+      CACHE.put(locale, create(locale))
     }
     CACHE.get(locale)
   }

--- a/core/shared/src/main/scala/org/threeten/bp/format/SimpleDateTimeFormatStyleProvider.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/format/SimpleDateTimeFormatStyleProvider.scala
@@ -34,15 +34,15 @@ package org.threeten.bp.format
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.Locale
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentMap
+import java.util.HashMap
+import java.util.Map
 import org.threeten.bp.chrono.Chronology
 
 private object SimpleDateTimeFormatStyleProvider {
 
   /** Cache of formatters. */
-  private val FORMATTER_CACHE: ConcurrentMap[String, AnyRef] =
-    new ConcurrentHashMap[String, AnyRef](16, 0.75f, 2)
+  private val FORMATTER_CACHE: Map[String, AnyRef] =
+    new HashMap[String, AnyRef]()
 }
 
 /** The Service Provider Implementation to obtain date-time formatters for a style.
@@ -83,10 +83,10 @@ final class SimpleDateTimeFormatStyleProvider extends DateTimeFormatStyleProvide
           val pattern: String = format.toPattern
           val formatter: DateTimeFormatter =
             new DateTimeFormatterBuilder().appendPattern(pattern).toFormatter(locale)
-          SimpleDateTimeFormatStyleProvider.FORMATTER_CACHE.putIfAbsent(key, formatter)
+          SimpleDateTimeFormatStyleProvider.FORMATTER_CACHE.put(key, formatter)
           formatter
         case _ =>
-          SimpleDateTimeFormatStyleProvider.FORMATTER_CACHE.putIfAbsent(key, "")
+          SimpleDateTimeFormatStyleProvider.FORMATTER_CACHE.put(key, "")
           throw new IllegalArgumentException("Unable to convert DateFormat to DateTimeFormatter")
       }
     }

--- a/core/shared/src/main/scala/org/threeten/bp/format/internal/TTBPSimpleDateTimeTextProvider.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/format/internal/TTBPSimpleDateTimeTextProvider.scala
@@ -39,8 +39,8 @@ import java.text.DateFormatSymbols
 import java.util.Calendar
 import java.util.GregorianCalendar
 import java.util.Locale
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentMap
+import java.util.HashMap
+import java.util.{ Map => JMap }
 
 import org.threeten.bp.temporal.IsoFields
 import org.threeten.bp.temporal.TemporalField
@@ -133,8 +133,8 @@ object TTBPSimpleDateTimeTextProvider {
 final class TTBPSimpleDateTimeTextProvider extends TTBPDateTimeTextProvider {
 
   /** Cache. */
-  private val cache: ConcurrentMap[(TemporalField, Locale), AnyRef] =
-    new ConcurrentHashMap[(TemporalField, Locale), AnyRef](16, 0.75f, 2)
+  private val cache: JMap[(TemporalField, Locale), AnyRef] =
+    new HashMap[(TemporalField, Locale), AnyRef]()
 
   override def getText(
     field:  TemporalField,
@@ -162,7 +162,7 @@ final class TTBPSimpleDateTimeTextProvider extends TTBPDateTimeTextProvider {
     var store: AnyRef = cache.get(key)
     if (store == null) {
       store = createStore(field, locale)
-      cache.putIfAbsent(key, store)
+      cache.put(key, store)
       store = cache.get(key)
     }
     store

--- a/core/shared/src/main/scala/org/threeten/bp/temporal/WeekFields.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/temporal/WeekFields.scala
@@ -43,8 +43,8 @@ import org.threeten.bp.temporal.ChronoUnit.YEARS
 import java.io.InvalidObjectException
 import java.io.Serializable
 import java.util.{ GregorianCalendar, Locale, Objects }
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentMap
+import java.util.HashMap
+import java.util.Map
 import org.threeten.bp.DateTimeException
 import org.threeten.bp.DayOfWeek
 import org.threeten.bp.Year
@@ -58,8 +58,8 @@ object WeekFields {
   /** The cache of rules by firstDayOfWeek plus minimalDays.
     * Initialized first to be available for definition of ISO, etc.
     */
-  private val CACHE: ConcurrentMap[String, WeekFields] =
-    new ConcurrentHashMap[String, WeekFields](4, 0.75f, 2)
+  private val CACHE: Map[String, WeekFields] =
+    new HashMap[String, WeekFields]()
 
   /** The ISO-8601 definition, where a week starts on Monday and the first week
     * has a minimum of 4 days.
@@ -123,7 +123,7 @@ object WeekFields {
     var rules: WeekFields = CACHE.get(key)
     if (rules == null) {
       rules = new WeekFields(firstDayOfWeek, minimalDaysInFirstWeek)
-      CACHE.putIfAbsent(key, rules)
+      CACHE.put(key, rules)
       rules = CACHE.get(key)
     }
     rules

--- a/core/shared/src/main/scala/org/threeten/bp/zone/StandardZoneRules.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/zone/StandardZoneRules.scala
@@ -37,8 +37,8 @@ import java.io.IOException
 import java.io.Serializable
 import java.util.Arrays
 import java.util.Collections
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentMap
+import java.util.HashMap
+import java.util.Map
 import org.threeten.bp.Duration
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
@@ -211,8 +211,8 @@ final class StandardZoneRules private (
     with Serializable {
 
   /** The map of recent transitions. */
-  private val lastRulesCache: ConcurrentMap[Integer, Array[ZoneOffsetTransition]] =
-    new ConcurrentHashMap[Integer, Array[ZoneOffsetTransition]]
+  private val lastRulesCache: Map[Integer, Array[ZoneOffsetTransition]] =
+    new HashMap[Integer, Array[ZoneOffsetTransition]]()
 
   /** Creates an instance. */
   /* // Can't be implemented with Scala's constructor rules. Replaced with apply factory method.
@@ -422,7 +422,7 @@ final class StandardZoneRules private (
     }
 
     if (year < StandardZoneRules.LAST_CACHED_YEAR)
-      lastRulesCache.putIfAbsent(yearObj, transArray)
+      lastRulesCache.put(yearObj, transArray)
     transArray
   }
 

--- a/core/shared/src/main/scala/org/threeten/bp/zone/ZoneRulesProvider.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/zone/ZoneRulesProvider.scala
@@ -32,19 +32,19 @@
 package org.threeten.bp.zone
 
 import java.util.{ Collections, Objects }
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentMap
-import java.util.concurrent.CopyOnWriteArrayList
+import java.util.HashMap
+import java.util.Map
+import java.util.ArrayList
 
 object ZoneRulesProvider {
 
   /** The set of loaded providers. */
-  private val PROVIDERS: CopyOnWriteArrayList[ZoneRulesProvider] =
-    new CopyOnWriteArrayList[ZoneRulesProvider]
+  private val PROVIDERS: ArrayList[ZoneRulesProvider] =
+    new ArrayList[ZoneRulesProvider]
 
   /** The lookup from zone region ID to provider. */
-  private val ZONES: ConcurrentMap[String, ZoneRulesProvider] =
-    new ConcurrentHashMap[String, ZoneRulesProvider](512, 0.75f, 2)
+  private val ZONES: Map[String, ZoneRulesProvider] =
+    new HashMap[String, ZoneRulesProvider]()
 
   /** Gets the set of available zone IDs.
     *
@@ -157,7 +157,7 @@ object ZoneRulesProvider {
     while (zoneIds.hasNext) {
       val zoneId = zoneIds.next()
       Objects.requireNonNull(zoneId, "zoneId")
-      val old: ZoneRulesProvider = ZONES.putIfAbsent(zoneId, provider)
+      val old: ZoneRulesProvider = ZONES.put(zoneId, provider)
       if (old != null)
         throw new ZoneRulesException(
           s"Unable to register zone as one already registered with that ID: $zoneId, currently loading from provider: $provider"


### PR DESCRIPTION
We can remove the use of `ConcurrentHashMap` as we don't need on the JS world. This reduces fullOptJS in about 1% on my limited tests