### PR TITLE
Fix implicit numeric widening

### DIFF
--- a/core/shared/src/main/scala/org/threeten/bp/chrono/HijrahChronology.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/chrono/HijrahChronology.scala
@@ -295,7 +295,7 @@ final class HijrahChronology private () extends Chronology with Serializable {
       if (resolverStyle ne ResolverStyle.LENIENT) {
         PROLEPTIC_MONTH.checkValidValue(prolepticMonth)
       }
-      updateResolveMap(fieldValues, MONTH_OF_YEAR, Math.floorMod(prolepticMonth, 12) + 1)
+      updateResolveMap(fieldValues, MONTH_OF_YEAR, Math.floorMod(prolepticMonth, 12) + 1L)
       updateResolveMap(fieldValues, YEAR, Math.floorDiv(prolepticMonth, 12))
     }
     val yoeLong: java.lang.Long = fieldValues.remove(YEAR_OF_ERA)

--- a/core/shared/src/main/scala/org/threeten/bp/chrono/IsoChronology.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/chrono/IsoChronology.scala
@@ -308,7 +308,7 @@ final class IsoChronology private () extends Chronology with Serializable {
     if (prolepticMonth != null) {
       if (resolverStyle ne ResolverStyle.LENIENT)
         PROLEPTIC_MONTH.checkValidValue(prolepticMonth)
-      updateResolveMap(fieldValues, MONTH_OF_YEAR, Math.floorMod(prolepticMonth, 12) + 1)
+      updateResolveMap(fieldValues, MONTH_OF_YEAR, Math.floorMod(prolepticMonth, 12) + 1L)
       updateResolveMap(fieldValues, YEAR, Math.floorDiv(prolepticMonth, 12))
     }
     val yoeLong: java.lang.Long = fieldValues.remove(YEAR_OF_ERA)

--- a/core/shared/src/main/scala/org/threeten/bp/chrono/JapaneseChronology.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/chrono/JapaneseChronology.scala
@@ -342,7 +342,7 @@ final class JapaneseChronology private () extends Chronology with Serializable {
     if (prolepticMonth != null) {
       if (resolverStyle ne ResolverStyle.LENIENT)
         PROLEPTIC_MONTH.checkValidValue(prolepticMonth)
-      updateResolveMap(fieldValues, MONTH_OF_YEAR, Math.floorMod(prolepticMonth, 12) + 1)
+      updateResolveMap(fieldValues, MONTH_OF_YEAR, Math.floorMod(prolepticMonth, 12) + 1L)
       updateResolveMap(fieldValues, YEAR, Math.floorDiv(prolepticMonth, 12))
     }
     val eraLong: java.lang.Long = fieldValues.get(ERA)

--- a/core/shared/src/main/scala/org/threeten/bp/chrono/MinguoChronology.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/chrono/MinguoChronology.scala
@@ -223,7 +223,7 @@ final class MinguoChronology private () extends Chronology with Serializable {
     if (prolepticMonth != null) {
       if (resolverStyle ne ResolverStyle.LENIENT)
         PROLEPTIC_MONTH.checkValidValue(prolepticMonth)
-      updateResolveMap(fieldValues, MONTH_OF_YEAR, Math.floorMod(prolepticMonth, 12) + 1)
+      updateResolveMap(fieldValues, MONTH_OF_YEAR, Math.floorMod(prolepticMonth, 12) + 1L)
       updateResolveMap(fieldValues, YEAR, Math.floorDiv(prolepticMonth, 12))
     }
     val yoeLong: java.lang.Long = fieldValues.remove(YEAR_OF_ERA)

--- a/core/shared/src/main/scala/org/threeten/bp/chrono/ThaiBuddhistChronology.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/chrono/ThaiBuddhistChronology.scala
@@ -256,7 +256,7 @@ final class ThaiBuddhistChronology private () extends Chronology with Serializab
     if (prolepticMonth != null) {
       if (resolverStyle ne ResolverStyle.LENIENT)
         PROLEPTIC_MONTH.checkValidValue(prolepticMonth)
-      updateResolveMap(fieldValues, MONTH_OF_YEAR, Math.floorMod(prolepticMonth, 12) + 1)
+      updateResolveMap(fieldValues, MONTH_OF_YEAR, Math.floorMod(prolepticMonth, 12) + 1L)
       updateResolveMap(fieldValues, YEAR, Math.floorDiv(prolepticMonth, 12))
     }
     val yoeLong: java.lang.Long = fieldValues.remove(YEAR_OF_ERA)

--- a/core/shared/src/main/scala/org/threeten/bp/format/DateTimeBuilder.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/format/DateTimeBuilder.scala
@@ -438,7 +438,7 @@ final class DateTimeBuilder() extends TemporalAccessor with Cloneable {
           }
         } else {
           val excessDays: Int = Math.toIntExact(Math.floorDiv(hodVal, 24L))
-          hodVal = Math.floorMod(hodVal, 24)
+          hodVal = Math.floorMod(hodVal, 24L)
           addObject(LocalTime.of(hodVal.toInt, 0))
           this.excessDays = Period.ofDays(excessDays)
         }


### PR DESCRIPTION
On my PC, `sbt compile` aborts due to the compile error regarding this numeric widening.
I think this error is enabled by `tpolecat` plubin in https://github.com/cquiroz/scala-java-time/blob/master/project/plugins.sbt#L16
It is weird that CI ignores this error.