### PR TITLE
Fix of OOM errors during compiling and testing the whole project in a batch more

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,6 @@
+-Xmx4g
+-Xss2m
+-XX:MaxMetaspaceSize=1g
+-XX:ReservedCodeCacheSize=512m
+-XX:+UseParallelGC
+-Dfile.encoding=UTF8


### PR DESCRIPTION
It fixes the slowdown and OOM errors with hanging when running the `sbt clean test` command:
```
[info] Fast optimizing /home/andriy/Projects/com/github/plokhotnyuk/scala-java-time/tests/js/target/scala-2.13/scala-java-time-tests-test-fastopt.js
Exception in thread "task-progress-report-thread" 
Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "task-progress-report-thread"
Exception in thread "classloader-cache-cleanup-0" java.lang.OutOfMemoryError: Java heap space
  at scala.runtime.IntRef.create(IntRef.java:23)
  at scala.util.hashing.MurmurHash3.unorderedHash(MurmurHash3.scala:94)
  at scala.util.hashing.MurmurHash3$.setHash(MurmurHash3.scala:230)
  at scala.collection.GenSetLike.hashCode(GenSetLike.scala:135)
	at scala.collection.GenSetLike.hashCode$(GenSetLike.scala:135)
	at scala.collection.AbstractSet.hashCode(Set.scala:51)
	at scala.runtime.Statics.anyHash(Statics.java:122)
	at scala.util.hashing.MurmurHash3.productHash(MurmurHash3.scala:68)
	at scala.util.hashing.MurmurHash3$.productHash(MurmurHash3.scala:215)
	at scala.runtime.ScalaRunTime$._hashCode(ScalaRunTime.scala:149)
	at scala.Tuple2.hashCode(Tuple2.scala:24)
	at scala.runtime.Statics.anyHash(Statics.java:122)
	at scala.collection.mutable.HashTable$HashUtils.elemHashCode(HashTable.scala:416)
	at scala.collection.mutable.HashTable$HashUtils.elemHashCode$(HashTable.scala:416)
	at scala.collection.mutable.HashMap.elemHashCode(HashMap.scala:44)
	at scala.collection.mutable.HashMap.getOrElseUpdate(HashMap.scala:80)
	at scala.collection.TraversableLike.$anonfun$groupBy$1(TraversableLike.scala:410)
	at scala.collection.TraversableLike$$Lambda$597/0x00000001006db840.apply(Unknown Source)
	at scala.collection.Iterator.foreach(Iterator.scala:941)
	at scala.collection.Iterator.foreach$(Iterator.scala:941)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1429)
	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
	at scala.collection.TraversableLike.groupBy(TraversableLike.scala:408)
	at scala.collection.TraversableLike.groupBy$(TraversableLike.scala:406)
	at scala.collection.AbstractTraversable.groupBy(Traversable.scala:108)
	at sbt.internal.classpath.ClassLoaderCache.sbt$internal$classpath$ClassLoaderCache$$clearExpiredLoaders(ClassLoaderCache.scala:87)
	at sbt.internal.classpath.ClassLoaderCache$CleanupThread.run(ClassLoaderCache.scala:108)
java.lang.OutOfMemoryError: Java heap space
^C
[warn] Canceling execution...
[error] Total time: 32553 s (09:02:33), completed Jul 8, 2020, 6:26:05 AM
```