### PR TITLE
Declare constants properly

### DIFF
--- a/core/jvm/src/main/scala/org/threeten/bp/chrono/HijrahDateConfigurator.scala
+++ b/core/jvm/src/main/scala/org/threeten/bp/chrono/HijrahDateConfigurator.scala
@@ -20,7 +20,7 @@ object HijrahDateConfigurator {
   private val PATH_SEP: String = File.pathSeparator
 
   /** Default config file name. */
-  private val DEFAULT_CONFIG_FILENAME: String = "hijrah_deviation.cfg"
+  private final val DEFAULT_CONFIG_FILENAME = "hijrah_deviation.cfg"
 
   /** Default path to the config file. */
   private val DEFAULT_CONFIG_PATH: String = s"org${FILE_SEP}threeten${FILE_SEP}bp${FILE_SEP}chrono"

--- a/core/shared/src/main/scala/org/threeten/bp/Duration.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/Duration.scala
@@ -61,16 +61,16 @@ object Duration {
   lazy val ZERO: Duration = new Duration(0, 0)
 
   /** Constant for nanos per second. */
-  private def NANOS_PER_SECOND: Int = 1000000000
+  private final val NANOS_PER_SECOND = 1000000000
 
   /** Constant for nanos per milli. */
-  private def NANOS_PER_MILLI: Int = 1000000
+  private final val NANOS_PER_MILLI = 1000000
 
   /** Constant for nanos per second. */
   private def BI_NANOS_PER_SECOND: BigInteger = BigInteger.valueOf(NANOS_PER_SECOND.toLong)
 
   /** The pattern for parsing. */
-  private def PATTERN: Pattern =
+  private lazy val PATTERN: Pattern =
     Pattern.compile(
       "([-+]?)P(?:([-+]?[0-9]+)D)?" + "(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?",
       Pattern.CASE_INSENSITIVE

--- a/core/shared/src/main/scala/org/threeten/bp/LocalTime.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/LocalTime.scala
@@ -87,40 +87,40 @@ object LocalTime {
   lazy val NOON: LocalTime = HOURS(12)
 
   /** Hours per day. */
-  private[bp] val HOURS_PER_DAY: Int = 24
+  private[bp] final val HOURS_PER_DAY = 24
 
   /** Minutes per hour. */
-  private[bp] val MINUTES_PER_HOUR: Int = 60
+  private[bp] final val MINUTES_PER_HOUR = 60
 
   /** Minutes per day. */
-  private[bp] val MINUTES_PER_DAY: Int = MINUTES_PER_HOUR * HOURS_PER_DAY
+  private[bp] final val MINUTES_PER_DAY = MINUTES_PER_HOUR * HOURS_PER_DAY
 
   /** Seconds per minute. */
-  private[bp] val SECONDS_PER_MINUTE: Int = 60
+  private[bp] final val SECONDS_PER_MINUTE = 60
 
   /** Seconds per hour. */
-  private[bp] val SECONDS_PER_HOUR: Int = SECONDS_PER_MINUTE * MINUTES_PER_HOUR
+  private[bp] final val SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR
 
   /** Seconds per day. */
-  private[bp] val SECONDS_PER_DAY: Int = SECONDS_PER_HOUR * HOURS_PER_DAY
+  private[bp] final val SECONDS_PER_DAY = SECONDS_PER_HOUR * HOURS_PER_DAY
 
   /** Milliseconds per day. */
-  private[bp] val MILLIS_PER_DAY: Long = SECONDS_PER_DAY * 1000L
+  private[bp] final val MILLIS_PER_DAY = SECONDS_PER_DAY * 1000L
 
   /** Microseconds per day. */
-  private[bp] val MICROS_PER_DAY: Long = SECONDS_PER_DAY * 1000000L
+  private[bp] final val MICROS_PER_DAY = SECONDS_PER_DAY * 1000000L
 
   /** Nanos per second. */
-  private[bp] val NANOS_PER_SECOND: Long = 1000000000L
+  private[bp] final val NANOS_PER_SECOND = 1000000000L
 
   /** Nanos per minute. */
-  private[bp] val NANOS_PER_MINUTE: Long = NANOS_PER_SECOND * SECONDS_PER_MINUTE
+  private[bp] final val NANOS_PER_MINUTE = NANOS_PER_SECOND * SECONDS_PER_MINUTE
 
   /** Nanos per hour. */
-  private[bp] val NANOS_PER_HOUR: Long = NANOS_PER_MINUTE * MINUTES_PER_HOUR
+  private[bp] final val NANOS_PER_HOUR = NANOS_PER_MINUTE * MINUTES_PER_HOUR
 
   /** Nanos per day. */
-  private[bp] val NANOS_PER_DAY: Long = NANOS_PER_HOUR * HOURS_PER_DAY
+  private[bp] final val NANOS_PER_DAY = NANOS_PER_HOUR * HOURS_PER_DAY
 
   /**
    * Obtains the current time from the system clock in the default time-zone.

--- a/core/shared/src/main/scala/org/threeten/bp/chrono/ChronoLocalDateTimeImpl.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/chrono/ChronoLocalDateTimeImpl.scala
@@ -49,40 +49,40 @@ import org.threeten.bp.temporal.ValueRange
 private[chrono] object ChronoLocalDateTimeImpl {
 
   /** Hours per minute. */
-  private val HOURS_PER_DAY: Int = 24
+  private final val HOURS_PER_DAY = 24
 
   /** Minutes per hour. */
-  private val MINUTES_PER_HOUR: Int = 60
+  private final val MINUTES_PER_HOUR = 60
 
   /** Minutes per day. */
-  private val MINUTES_PER_DAY: Int = MINUTES_PER_HOUR * HOURS_PER_DAY
+  private final val MINUTES_PER_DAY = MINUTES_PER_HOUR * HOURS_PER_DAY
 
   /** Seconds per minute. */
-  private val SECONDS_PER_MINUTE: Int = 60
+  private final val SECONDS_PER_MINUTE = 60
 
   /** Seconds per hour. */
-  private val SECONDS_PER_HOUR: Int = SECONDS_PER_MINUTE * MINUTES_PER_HOUR
+  private final val SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR
 
   /** Seconds per day. */
-  private val SECONDS_PER_DAY: Int = SECONDS_PER_HOUR * HOURS_PER_DAY
+  private final val SECONDS_PER_DAY = SECONDS_PER_HOUR * HOURS_PER_DAY
 
   /** Milliseconds per day. */
-  private val MILLIS_PER_DAY: Long = SECONDS_PER_DAY * 1000L
+  private final val MILLIS_PER_DAY = SECONDS_PER_DAY * 1000L
 
   /** Microseconds per day. */
-  private val MICROS_PER_DAY: Long = SECONDS_PER_DAY * 1000000L
+  private final val MICROS_PER_DAY = SECONDS_PER_DAY * 1000000L
 
   /** Nanos per second. */
-  private val NANOS_PER_SECOND: Long = 1000000000L
+  private final val NANOS_PER_SECOND = 1000000000L
 
   /** Nanos per minute. */
-  private val NANOS_PER_MINUTE: Long = NANOS_PER_SECOND * SECONDS_PER_MINUTE
+  private final val NANOS_PER_MINUTE = NANOS_PER_SECOND * SECONDS_PER_MINUTE
 
   /** Nanos per hour. */
-  private val NANOS_PER_HOUR: Long = NANOS_PER_MINUTE * MINUTES_PER_HOUR
+  private final val NANOS_PER_HOUR = NANOS_PER_MINUTE * MINUTES_PER_HOUR
 
   /** Nanos per day. */
-  private val NANOS_PER_DAY: Long = NANOS_PER_HOUR * HOURS_PER_DAY
+  private final val NANOS_PER_DAY = NANOS_PER_HOUR * HOURS_PER_DAY
 
   /**
    * Obtains an instance of {@code ChronoLocalDateTime} from a date and time.

--- a/core/shared/src/main/scala/org/threeten/bp/chrono/HijrahDate.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/chrono/HijrahDate.scala
@@ -63,13 +63,13 @@ import org.threeten.bp.temporal.ValueRange
 object HijrahDate {
 
   /** The minimum valid year-of-era. */
-  val MIN_VALUE_OF_ERA: Int = 1
+  final val MIN_VALUE_OF_ERA = 1
 
   /**
    * The maximum valid year-of-era. This is currently set to 9999 but may be changed to increase the
    * valid range in a future version of the specification.
    */
-  val MAX_VALUE_OF_ERA: Int = 9999
+  final val MAX_VALUE_OF_ERA = 9999
 
   /**
    * 0-based, for number of day-of-year in the beginning of month in normal year.
@@ -106,12 +106,12 @@ object HijrahDate {
   /**
    * Position of day-of-month. This value is used to get the min/max value from an array.
    */
-  private val POSITION_DAY_OF_MONTH: Int = 5
+  private final val POSITION_DAY_OF_MONTH = 5
 
   /**
    * Position of day-of-year. This value is used to get the min/max value from an array.
    */
-  private val POSITION_DAY_OF_YEAR: Int = 6
+  private final val POSITION_DAY_OF_YEAR = 6
 
   /** Zero-based start date of cycle year. */
   private lazy val CYCLEYEAR_START_DATE: Array[Int] =

--- a/core/shared/src/main/scala/org/threeten/bp/zone/StandardZoneRules.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/zone/StandardZoneRules.scala
@@ -47,7 +47,7 @@ import org.threeten.bp.ZoneOffset
 object StandardZoneRules {
 
   /** The last year to have its transitions cached. */
-  private val LAST_CACHED_YEAR: Int = 2100
+  private final val LAST_CACHED_YEAR = 2100
 
   /**
    * Creates an instance.


### PR DESCRIPTION
> A constant value definition is of the form
> ```scala
> final val x = e
> ```
> where `e` is a [constant expression](https://www.scala-lang.org/files/archive/spec/2.13/06-expressions.html#constant-expressions). The final modifier must be present and no type annotation may be given. References to the constant value `x` are themselves treated as constant expressions; in the generated code they are replaced by the definition's right-hand side `e`.

https://www.scala-lang.org/files/archive/spec/2.13/04-basic-declarations-and-definitions.html#value-declarations-and-definitions