### PR TITLE
ZoneOffset.of("Z") must return UTC

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val scala3   = "3.3.3"
 ThisBuild / scalaVersion       := scala213
 ThisBuild / crossScalaVersions := Seq("2.12.17", scala213, scala3)
 
-ThisBuild / tlBaseVersion := "2.5"
+ThisBuild / tlBaseVersion := "2.6"
 
 ThisBuild / githubWorkflowBuildMatrixFailFast := Some(false)
 

--- a/core/shared/src/main/scala/org/threeten/bp/ZoneOffset.scala
+++ b/core/shared/src/main/scala/org/threeten/bp/ZoneOffset.scala
@@ -103,7 +103,9 @@ object ZoneOffset {
     var _offsetId = offsetId
     Objects.requireNonNull(_offsetId, "offsetId")
 
-    // "Z" is always in the cache
+    if (_offsetId == "Z")
+      return ZoneOffset.UTC
+
     val offset: ZoneOffset = ID_CACHE.get(_offsetId)
     if (offset != null)
       return offset


### PR DESCRIPTION
Closes #518 

It seems that this used to work, but relied on the fact that `ZoneOffset.UTC` will put "Z" in 
ID_CACHE when object is initialised.

This no longer works because ZoneOffset.UTC was made into a lazy val, so invoking `ZoneOffset.of("Z")` will not trigger the `ZoneOffset.UTC` calculation.

To confirm, just touching ZoneOffset.UTC is enough to make repro work:

```
scala-cli -e 'java.time.ZoneOffset.UTC;java.time.ZoneOffset.of("Z")' --js --dep io.github.cquiroz::scala-java-time::2.6.0 # succeeds
```

I feel like relying on this cache behaviour is too brittle, so I decided to explictly special-case "Z" as it's a special case in java docs as well.

---

Note that this case is already tested, but one of the previous tests refers to ZoneOffset.UTC, triggering the cache update.