### PR TITLE
Fix source map URLs (as much as possible). Fixes #519

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ tzdb/js/src/main/resources/
 project/metals.sbt
 .direnv/
 .bsp/
+
+.DS_Store


### PR DESCRIPTION
I think this is the best I can do for https://github.com/cquiroz/scala-java-time/issues/519

scala-java-time build does some non-standard things that make supporting fully correct source maps pretty hard. But, we can get pretty close. This PR fixes the URLs for all source maps under `core/shared`. Unfortunately, the source maps for `core/js` remain broken, but most files are in `shared`. Someone strong in sbt may be able to improve on this, but absent of that, my vote is that it's good enough.

Also, scala-java-time build transforms the content of the source files (changes packages / imports / etc.) – FYI, to the extent that this modifies positions of terms in the source code, this could break source maps as well. But, most of the transformations are line-for-line replacements of imports and package names, which should keep the rest of the file unaffected.

In practice, the source maps generated with the new code seem to work just fine for me.

**This PR introduces a change in the src_managed folder structure for the `core/js` project.** Instead of copying source files into `src_managed/main/org/threeteen/...`, we now move files into `src_managed/main/scala/org/threeteen/...` (the `scala` part changes to `scala-3` for sources that are located in `scala-3`).

I published the `core` module locally, and used it from my Scala 3 project, and it works fine, source maps included. It seems that these changes should even be binary compatible, seeing that only the folder structure is changed, not package names?